### PR TITLE
updated createConsent to return deployed consent address

### DIFF
--- a/packages/contracts-sdk/src/interfaces/IConsentFactoryContract.ts
+++ b/packages/contracts-sdk/src/interfaces/IConsentFactoryContract.ts
@@ -19,7 +19,7 @@ export interface IConsentFactoryContract {
     ownerAddress: EVMAccountAddress,
     baseUri: string,
     overrides?: ContractOverrides,
-  ): ResultAsync<void, ConsentFactoryContractError>;
+  ): ResultAsync<EVMContractAddress, ConsentFactoryContractError>;
 
   /**
    *  Return the number Consent addresses that user has deployed


### PR DESCRIPTION
- Added a filter to the createConsent function to get get the deployed Consent address from the tx receipt's logs