### PR TITLE
re-added createConsent name parameter

### DIFF
--- a/packages/contracts-sdk/src/implementations/ConsentFactoryContract.ts
+++ b/packages/contracts-sdk/src/implementations/ConsentFactoryContract.ts
@@ -11,7 +11,7 @@ import {
 import { ethers, BigNumber } from "ethers";
 import { EventFragment } from "ethers/lib/utils";
 import { injectable } from "inversify";
-import { ResultAsync } from "neverthrow";
+import { ResultAsync, okAsync } from "neverthrow";
 @injectable()
 export class ConsentFactoryContract implements IConsentFactoryContract {
   protected contract: ethers.Contract;
@@ -35,12 +35,14 @@ export class ConsentFactoryContract implements IConsentFactoryContract {
   public createConsent(
     ownerAddress: EVMAccountAddress,
     baseUri: string,
+    name: string,
     overrides?: ContractOverrides,
   ): ResultAsync<EVMContractAddress, ConsentFactoryContractError> {
     return ResultAsync.fromPromise(
       this.contract.createConsent(
         ownerAddress,
         baseUri,
+        name,
         overrides,
       ) as Promise<ethers.providers.TransactionResponse>,
       (e) => {

--- a/packages/contracts-sdk/src/interfaces/IConsentFactoryContract.ts
+++ b/packages/contracts-sdk/src/interfaces/IConsentFactoryContract.ts
@@ -13,11 +13,13 @@ export interface IConsentFactoryContract {
    * Creates a consent contract for user
    * @param ownerAddress Address of the owner of the Consent contract instance
    * @param baseUri Base uri for the for the Consent contract instance
+   * @param name Name of the Consent contract address
    * @param overrides Any transaction call overrides
    */
   createConsent(
     ownerAddress: EVMAccountAddress,
     baseUri: string,
+    name: string,
     overrides?: ContractOverrides,
   ): ResultAsync<EVMContractAddress, ConsentFactoryContractError>;
 


### PR DESCRIPTION
hey @moahammadalt , sorry about the misleading reply yesterday. we do still need name when creating a consent contract so am adding this back in.