### PR TITLE
added Sift tasks, updated constants and README

### DIFF
--- a/packages/contracts/hardhat.config.js
+++ b/packages/contracts/hardhat.config.js
@@ -13,6 +13,7 @@ require("./tasks/queries.js");
 require("./tasks/consent.js");
 require("./tasks/crumbs.js");
 require("./tasks/utils.js");
+require("./tasks/sift.js");
 
 require("dotenv").config();
 

--- a/packages/contracts/tasks/README.md
+++ b/packages/contracts/tasks/README.md
@@ -202,7 +202,7 @@ AccessControl: account 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc is missing rol
 We can create crumbs:
 
 ```
-npx hardhat createCrumb --crumbid 1 --mask 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --owneraddressindex 0 --network dev
+npx hardhat createCrumb --crumbid 1 --tokenuri 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --owneraddressindex 0 --network dev
 
 /*
 
@@ -220,6 +220,65 @@ npx hardhat burnCrumb --crumbid 1 --owneraddressindex 0 --network dev
 /*
 
 Success! Crumb id 1 burnt from address 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266.
+
+*/
+```
+
+## Sift Contract Tasks
+
+We can verify urls on the Sift contract by running:
+
+```
+npx hardhat verifyURL --url www.domain.com --owner 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --owneraddressindex 0 --network dev
+
+/*
+
+Success! URL www.domain.com is now set as VERIFIED on the Sift Contract.
+
+*/
+
+```
+
+We can also mark urls on the Sift contract as malicious by running:
+
+```
+npx hardhat maliciousURL --url www.baddomain.com --owner 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --owneraddressindex 0 --network dev
+
+/*
+
+Success! URL www.baddomain.com is now marked as MALICIOUS on the Sift Contract.
+
+*/
+```
+
+To check any url's status on the contract, run the following:
+
+```
+npx hardhat checkURL --url www.domain.com --network dev
+
+/*
+
+Checked! URL www.domain.com is www.sift.com/VERIFIED.
+
+*/
+```
+
+```
+npx hardhat checkURL --url www.baddomain.com --network dev
+
+*/
+
+Checked! URL www.baddomain.com is www.sift.com/MALICIOUS.
+
+*/
+```
+
+```
+npx hardhat checkURL --url www.new.com --network dev
+
+*/
+
+Checked! URL www.new.com is NOT VERIFIED.
 
 */
 ```

--- a/packages/contracts/tasks/constants.js
+++ b/packages/contracts/tasks/constants.js
@@ -29,6 +29,15 @@ const CR = function () {
   }
 };
 
+const SIFT = function () {
+  const artifactPath = "./artifacts/contracts/registry/Sift.sol/Sift.json";
+  if (fs.existsSync(artifactPath)) {
+    return require("../" + artifactPath);
+  } else {
+    return null;
+  }
+};
+
 const gasSettings = async function (txCount) {
   const hre = require("hardhat");
   const [account] = await hre.ethers.getSigners();
@@ -104,10 +113,36 @@ const crumbsContract = function () {
   const hre = require("hardhat");
   if (hre.hardhatArguments.network == "dev") {
     return "0x0165878A594ca255338adfa4d48449f69242Eb8F";
-  } else if (hre.hardhatArguments.network =="localhost") {
+  } else if (hre.hardhatArguments.network == "localhost") {
     return "0x0165878A594ca255338adfa4d48449f69242Eb8F";
   } else if (hre.hardhatArguments.network == "hardhat") {
     return "0x0165878A594ca255338adfa4d48449f69242Eb8F";
+  } else if (hre.hardhatArguments.network == "mumbai") {
+    return "";
+  } else if (hre.hardhatArguments.network == "polygon") {
+    return "";
+  } else if (hre.hardhatArguments.network == "fuji") {
+    return "";
+  } else if (hre.hardhatArguments.network == "avalanche") {
+    return "";
+  } else if (hre.hardhatArguments.network == "fantom") {
+    return "";
+  } else if (hre.hardhatArguments.network == "mainnet") {
+    return "";
+  } else {
+    return "";
+  }
+};
+
+// define some dynamic imports
+const siftContract = function () {
+  const hre = require("hardhat");
+  if (hre.hardhatArguments.network == "dev") {
+    return "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853";
+  } else if (hre.hardhatArguments.network == "localhost") {
+    return "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853";
+  } else if (hre.hardhatArguments.network == "hardhat") {
+    return "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853";
   } else if (hre.hardhatArguments.network == "mumbai") {
     return "";
   } else if (hre.hardhatArguments.network == "polygon") {
@@ -145,4 +180,6 @@ module.exports = {
   countryCode,
   CR,
   crumbsContract,
+  SIFT,
+  siftContract,
 };

--- a/packages/contracts/tasks/sift.js
+++ b/packages/contracts/tasks/sift.js
@@ -1,0 +1,84 @@
+const { SIFT, siftContract } = require("./constants.js");
+
+task("verifyURL", "Verifies a url on the Sift contract")
+  .addParam("url", "Domain to verify")
+  .addParam("owner", "Address to mint the Sift token to")
+  .addParam(
+    "owneraddressindex",
+    "Index or owner address of the connected wallet to generate Signer object to sign the tx.",
+  )
+  .setAction(async (taskArgs) => {
+    const accounts = await hre.ethers.getSigners();
+
+    const signingAccount = accounts[taskArgs.owneraddressindex];
+
+    // attach the first signer account to the consent contract handle
+    const siftContractHandle = new hre.ethers.Contract(
+      siftContract(),
+      SIFT().abi,
+      signingAccount,
+    );
+
+    await siftContractHandle
+      .connect(signingAccount)
+      .verifyURL(taskArgs.url, taskArgs.owner);
+
+    console.log("");
+    console.log(
+      "Success! URL " +
+        taskArgs.url +
+        " is now set as VERIFIED on the Sift Contract.",
+    );
+    console.log("");
+  });
+
+task("maliciousURL", "Sets a url as malicious on the Sift contract")
+  .addParam("url", "Domain to set as malicious")
+  .addParam("owner", "Address to mint the Sift token to")
+  .addParam(
+    "owneraddressindex",
+    "Index or owner address of the connected wallet to generate Signer object to sign the tx.",
+  )
+  .setAction(async (taskArgs) => {
+    const accounts = await hre.ethers.getSigners();
+
+    const signingAccount = accounts[taskArgs.owneraddressindex];
+
+    // attach the first signer account to the consent contract handle
+    const siftContractHandle = new hre.ethers.Contract(
+      siftContract(),
+      SIFT().abi,
+      signingAccount,
+    );
+
+    await siftContractHandle
+      .connect(signingAccount)
+      .maliciousURL(taskArgs.url, taskArgs.owner);
+
+    console.log("");
+    console.log(
+      "Success! URL " +
+        taskArgs.url +
+        " is now marked as MALICIOUS on the Sift Contract.",
+    );
+    console.log("");
+  });
+
+task("checkURL", "Checks a url on the Sift Contract")
+  .addParam("url", "Domain to check")
+  .setAction(async (taskArgs) => {
+    const accounts = await hre.ethers.getSigners();
+
+    // attach the first signer account to the consent contract handle
+    const siftContractHandle = new hre.ethers.Contract(
+      siftContract(),
+      SIFT().abi,
+      accounts[0],
+    );
+
+    const result = await siftContractHandle.checkURL(taskArgs.url);
+
+    console.log("");
+    console.log("Checked! URL " + taskArgs.url + " is " + result + ".");
+    console.log("");
+  });


### PR DESCRIPTION
This PR adds hardhat tasks for the Sift contract which will enable us to register urls onto the Sift contract. 

README for how to use the Sift's tasks have been added and the contracts containing the addresses the tasks reference are also updated. 