### PR TITLE
added second IPFS call in getFileByCIDInternal

### DIFF
--- a/packages/core/src/implementations/data/InvitationRepository.ts
+++ b/packages/core/src/implementations/data/InvitationRepository.ts
@@ -62,12 +62,17 @@ export class InvitationRepository implements IInvitationRepository {
 
     const json = JSON.parse(raw) as IOpenSeaMetadata;
 
+    // Image property in the first JSON detail is also an IPFS CID, 
+    // make a second call to get the actual image URL before returning it in the InvitationDomain
+    // eg. Image could be store on GCP/IPFS itself
+    const imageURL = await this.getImageByCIDInternal(client, json.image);
+
     // Create the InvitationDomain
     const invitationDomain = new InvitationDomain(
       domain,
       json.title,
       json.description,
-      json.image,
+      imageURL,
       json.rewardName,
       json.nftClaimedImage,
     );
@@ -77,6 +82,39 @@ export class InvitationRepository implements IInvitationRepository {
 
     // Return the query
     return invitationDomain;
+  }
+  
+  // Second IPFS fetch call to get the image's actual URL before storing it into invitation domain
+  protected async getImageByCIDInternal(
+    client: IPFSHTTPClient,
+    cid: IpfsCID,
+  ): Promise<InvitationDomain | null> {
+    // calling cat command based on JS HTTP client API docs
+    // https://github.com/ipfs/js-ipfs/tree/master/packages/ipfs-http-client
+    const result = await client.cat(cid);
+    let content = new Array<number>();
+    for await (const chunk of result) {
+      content = [...content, ...chunk];
+    }
+    // conversion of U8s to readable content
+    const raw = Buffer.from(content).toString("utf8");
+
+    // If there is no data in IPFS for this CID, return null
+    if (raw.length == 0) {
+      return null;
+    }
+
+    const json = JSON.parse(raw) as URL;
+
+    // Here need to fetch IPFS CID again for the image 
+
+    // Create the InvitationDomain
+    const imageURL = new URL(
+      json
+    );
+
+    // Return the image's url
+    return imageURL;
   }
 }
 


### PR DESCRIPTION
The `image` value of the ERC721's baseURI metadata we will store is also an IPFS CID to its actual image url. 

Adding a second IPFS call in `getFileByCIDInternal` named `getImageByCIDInternal` to get the image URL before setting it in `InvitationDomain()`. 

