### PR TITLE
SDQL Object definition per SDQL syntax definition

### DIFF
--- a/packages/objects/src/interfaces/ISDQLQueryObject.ts
+++ b/packages/objects/src/interfaces/ISDQLQueryObject.ts
@@ -63,7 +63,9 @@ export interface ISDQLQueryConditions {
 }
 
 export interface ISDQLHasObject {
-  patternProperties: number;
+  patternProperties: {
+    [url: string]: number;
+  };
 }
 
 export interface ISDQLReturnProperties {


### PR DESCRIPTION
The insight-platform needs a defined SDQL query object for usage in Post/Add query to manipulate content.
After this is approved, will npm publish a new snickerdoodlelabs/object library that will be used for insight-platform