### PR TITLE
Rewrote CryptoUtils.getTokenId to use randomBytes()

### DIFF
--- a/packages/common-utils/src/implementations/CryptoUtils.ts
+++ b/packages/common-utils/src/implementations/CryptoUtils.ts
@@ -37,7 +37,16 @@ export class CryptoUtils implements ICryptoUtils {
   }
 
   public getTokenId(): ResultAsync<TokenId, never> {
-    return okAsync(TokenId(BigInt(Crypto.randomInt(281474976710655))));
+    const buf = Crypto.randomBytes(8);
+    const hex = buf.toString("hex");
+    const bigInt = BigInt(`0x${hex}`);
+
+    return okAsync(TokenId(bigInt));
+
+    // This older implementation I'm leaving as a comment. It's very clean, but does not
+    // work in a service worker, because the polyfills available do not support randomInt().
+    // Ye be warned.
+    //return okAsync(TokenId(BigInt(Crypto.randomInt(281474976710655))));
   }
 
   public deriveAESKeyFromSignature(

--- a/packages/common-utils/test/unit/CryptoUtils.test.ts
+++ b/packages/common-utils/test/unit/CryptoUtils.test.ts
@@ -36,6 +36,21 @@ describe("CryptoUtils tests", () => {
     expect(nonce.length).toBe(64);
   });
 
+  test("getTokenId returns a bigInt", async () => {
+    // Arrange
+    const mocks = new CryptoUtilsMocks();
+    const utils = mocks.factoryCryptoUtils();
+
+    // Act
+    const result = await utils.getTokenId();
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(result.isErr()).toBeFalsy();
+    const tokenId = result._unsafeUnwrap();
+    expect(tokenId).toBeGreaterThanOrEqual(0);
+  });
+
   test("deriveAESKeyFromSignature returns 32 bytes as 44 characters of base64", async () => {
     // Arrange
     const mocks = new CryptoUtilsMocks();


### PR DESCRIPTION
randomInt() is not supported by polyfills.