### PR TITLE
fixed 2 issues

### DIFF
--- a/packages/core/src/implementations/business/utilities/query/AST_Evaluator.ts
+++ b/packages/core/src/implementations/business/utilities/query/AST_Evaluator.ts
@@ -208,7 +208,7 @@ export class AST_Evaluator {
         return okAsync(SDQL_Return(false));
       } else {
         return this.evalAny(cond.rval).andThen((rval) => {
-          return okAsync(SDQL_Return(rval == false));
+          return okAsync(rval);
         });
       }
     });

--- a/packages/core/src/interfaces/objects/SDQL/TypeChecker.ts
+++ b/packages/core/src/interfaces/objects/SDQL/TypeChecker.ts
@@ -24,7 +24,7 @@ export class TypeChecker {
      */
     return !(
       expr instanceof AST_Expr ||
-      TypeChecker.isQuery ||
+      TypeChecker.isQuery(expr) ||
       TypeChecker.isOperator(expr) ||
       TypeChecker.isCommand(expr)
     );


### PR DESCRIPTION
1. TypeChecker.isValue was returning false even when the value is a primitive one.
2. andLogic fixed after a mistake from refactorization. It was returning true when rval was evaluated to false.