### PR TITLE
update to trusted forwarder address in Consent.sol

### DIFF
--- a/packages/contracts/DEPLOYMENTS.md
+++ b/packages/contracts/DEPLOYMENTS.md
@@ -32,7 +32,7 @@ Official Avalanche Network testnet:
 
 - Consent Contract Factory: `0xC44C9B4375ab43D7974252c37bccb41F99910fA5`
 - Crumbs Contract: `0x97464F3547510fb430448F5216eC7D8e71D7C4eF`
-- Consent Implementation Contract: `0xa62409d7aD53Ed3b5b61b261CC24884205e92e2a`
+- Consent Implementation Contract: `0xa2d4E987291d996d0293CD7Ec7951F357d9656E6`
 - DoodleToken Contract: `TBD`
 - Snickerdoodle Timelock Contract: `TBD`
 - Snickerdoodle Governor Contract: `TBD`

--- a/packages/contracts/contracts/consent/Consent.sol
+++ b/packages/contracts/contracts/consent/Consent.sol
@@ -88,7 +88,7 @@ contract Consent is Initializable, ERC721URIStorageUpgradeable, PausableUpgradea
         consentFactoryInstance = IConsentFactory(consentFactoryAddress);
 
         // set trusted forwarder
-        trustedForwarder = 0x5FbDB2315678afecb367f032d93F642f64180aa3; 
+        trustedForwarder = 0xF7c6dC708550D89558110cAecD20a8A6a184427E; 
 
         // use user to bypass the call back to the ConsentFactory to update the user's roles array mapping 
         super._grantRole(DEFAULT_ADMIN_ROLE, consentOwner);

--- a/packages/contracts/hardhat.config.js
+++ b/packages/contracts/hardhat.config.js
@@ -75,7 +75,7 @@ module.exports = {
     doodle: {
       accounts: accounts,
       chainId: 31337,
-      url: "https://doodlechain.snickerdoodle.dev",
+      url: "https://doodlechain.snickerdoodle.com",
       gas: 6000000,
       gasPrice: 8000000000,
     },

--- a/packages/contracts/scripts/consent-implementation-only.js
+++ b/packages/contracts/scripts/consent-implementation-only.js
@@ -1,0 +1,42 @@
+// We require the Hardhat Runtime Environment explicitly here. This is optional
+// but useful for running the script in a standalone fashion through `node <script>`.
+//
+// When running the script with `npx hardhat run <script>` you'll find the Hardhat
+// Runtime Environment's members available in the global scope.
+const hre = require("hardhat");
+//const { ethers, upgrades } = require("hardhat");
+
+// declare variables that need to be referenced by other functions
+let consentAddress;
+
+// function to deploy the consent contract
+async function deployConsent() {
+  console.log("");
+  console.log("Deploying Consent implementation contract...");
+
+  const Consent = await hre.ethers.getContractFactory("Consent");
+  const consent = await Consent.deploy();
+  const consent_receipt = await consent.deployTransaction.wait();
+  consentAddress = consent.address;
+
+  console.log("Consent deployed to:", consent.address);
+  console.log("Consent Gas Fee:", consent_receipt.gasUsed.toString());
+}
+
+// function that runs the full deployment of all contracts
+async function fullDeployment() {
+  await deployConsent();
+
+  console.log("");
+  console.log("Consent Contract implementation deployment successful!");
+  console.log("");
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+fullDeployment()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/packages/contracts/tasks/consent.js
+++ b/packages/contracts/tasks/consent.js
@@ -1,10 +1,74 @@
 const { task } = require("hardhat/config.js");
 const {
   logTXDetails,
+  consentBeacon,
   consentFactory,
+  BEACON,
   CC,
   CCFactory,
 } = require("./constants.js");
+
+task(
+  "getConsentBeacon",
+  "Check the address of the Consent Contract Beacon implementation.",
+).setAction(async (taskArgs) => {
+  const useraccount = taskArgs.useraddress;
+  const contractaddress = taskArgs.contractaddress;
+  const provider = await hre.ethers.provider;
+
+  // attach the first signer account to the consent contract handle
+  const factoryHandle = new hre.ethers.Contract(
+    consentFactory(),
+    CCFactory().abi,
+    provider,
+  );
+  let beaconHandle;
+  await factoryHandle.beaconAddress().then((beacon) => {
+    console.log("Beacon address is:", beacon);
+    return beacon;
+  }).then((beacon) => {
+    beaconHandle = new hre.ethers.Contract(
+      beacon,
+      BEACON().abi,
+      provider
+    );
+    return beaconHandle.implementation();
+  }).then((implementation) => {
+    console.log("Implementation address is:", implementation);
+    return beaconHandle.owner();
+  }).then((beaconOwner) => {
+    console.log("Beacon Owner is:", beaconOwner);
+  });
+});
+
+task("setConsentImplementation", "Set a new address for the UpgradableBeacon implementation.")
+  .addParam("implementation", "address of the implementation")
+  .addParam(
+    "accountnumber",
+    "integer referencing the account to you in the configured HD Wallet",
+  )
+  .setAction(async (taskArgs) => {
+    const implementation = taskArgs.implementation;
+    const accountnumber = taskArgs.accountnumber;
+    const accounts = await hre.ethers.getSigners();
+    const account = accounts[accountnumber];
+
+    // attach the first signer account to the consent contract handle
+    const beaconHandle = new hre.ethers.Contract(
+      consentBeacon(),
+      BEACON().abi,
+      account,
+    );
+
+    await beaconHandle
+      .upgradeTo(implementation)
+      .then((txresponse) => {
+        return txresponse.wait();
+      })
+      .then((txrct) => {
+        logTXDetails(txrct);
+      });
+  });
 
 task("checkBalanceOf", "Check balance of an address given a ERC721 address")
   .addParam("useraddress", "address of the users account")
@@ -18,20 +82,21 @@ task("checkBalanceOf", "Check balance of an address given a ERC721 address")
     const consentContractHandle = new hre.ethers.Contract(
       contractaddress,
       CC().abi,
-      provider
+      provider,
     );
 
-    await consentContractHandle
-      .balanceOf(useraccount).then((result) => {
-        console.log("ERC721 balance is:", result.toString());
-      });
-
+    await consentContractHandle.balanceOf(useraccount).then((result) => {
+      console.log("ERC721 balance is:", result.toString());
+    });
   });
 
 task("optIn", "Opt in to a Consent Contract")
   .addParam("contractaddress", "address of the consent contract")
   .addParam("tokenid", "token id to use for the optin token")
-  .addParam("accountnumber", "integer referencing the account to you in the configured HD Wallet")
+  .addParam(
+    "accountnumber",
+    "integer referencing the account to you in the configured HD Wallet",
+  )
   .setAction(async (taskArgs) => {
     const contractaddress = taskArgs.contractaddress;
     const tokenid = taskArgs.tokenid;
@@ -39,23 +104,58 @@ task("optIn", "Opt in to a Consent Contract")
     const accounts = await hre.ethers.getSigners();
     const account = accounts[accountnumber];
 
+    // attach the first signer account to the consent contract handle
+    const consentContractHandle = new hre.ethers.Contract(
+      contractaddress,
+      CC().abi,
+      account,
+    );
+
+    await consentContractHandle
+      .optIn(tokenid, "")
+      .then((txresponse) => {
+        return txresponse.wait();
+      })
+      .then((txrct) => {
+        logTXDetails(txrct);
+      });
+  });
+
+task("optOut", "Opt in to a Consent Contract")
+  .addParam("contractaddress", "address of the consent contract")
+  .addParam("tokenid", "token id to use for the optin token")
+  .addParam(
+    "accountnumber",
+    "integer referencing the account to you in the configured HD Wallet",
+  )
+  .setAction(async (taskArgs) => {
+    const contractaddress = taskArgs.contractaddress;
+    const tokenid = taskArgs.tokenid;
+    const accountnumber = taskArgs.accountnumber;
+    const accounts = await hre.ethers.getSigners();
+    const account = accounts[accountnumber];
 
     // attach the first signer account to the consent contract handle
     const consentContractHandle = new hre.ethers.Contract(
       contractaddress,
       CC().abi,
-      account
+      account,
     );
 
-    await consentContractHandle.optIn(tokenid, "")
+    await consentContractHandle
+      .optOut(tokenid, "")
       .then((txresponse) => {
-        return txresponse.wait()
-      }).then((txrct) => {
+        return txresponse.wait();
+      })
+      .then((txrct) => {
         logTXDetails(txrct);
       });
   });
 
-task("getTrustedForwarder", "returns the trusted forwarder address of a consent contract")
+task(
+  "getTrustedForwarder",
+  "returns the trusted forwarder address of a consent contract",
+)
   .addParam("contractaddress", "address of the consent contract")
   .setAction(async (taskArgs) => {
     const contractaddress = taskArgs.contractaddress;
@@ -65,7 +165,7 @@ task("getTrustedForwarder", "returns the trusted forwarder address of a consent 
     const consentContractHandle = new hre.ethers.Contract(
       contractaddress,
       CC().abi,
-      provider
+      provider,
     );
 
     await consentContractHandle.trustedForwarder().then((tfAddress) => {
@@ -73,10 +173,16 @@ task("getTrustedForwarder", "returns the trusted forwarder address of a consent 
     });
   });
 
-task("setTrustedForwarder", "sets the trusted forwarder address of a consent contract")
+task(
+  "setTrustedForwarder",
+  "sets the trusted forwarder address of a consent contract",
+)
   .addParam("contractaddress", "address of the consent contract")
   .addParam("trustedforwarder", "address to use as the trusted forwarder")
-  .addParam("accountnumber", "integer referencing the account to you in the configured HD Wallet")
+  .addParam(
+    "accountnumber",
+    "integer referencing the account to you in the configured HD Wallet",
+  )
   .setAction(async (taskArgs) => {
     const contractaddress = taskArgs.contractaddress;
     const trustedforwarder = taskArgs.trustedforwarder;
@@ -88,11 +194,12 @@ task("setTrustedForwarder", "sets the trusted forwarder address of a consent con
     const consentContractHandle = new hre.ethers.Contract(
       contractaddress,
       CC().abi,
-      account
+      account,
     );
 
     console.log("Attempting to set tf to:", trustedforwarder);
-    await consentContractHandle.setTrustedForwarder(trustedforwarder)
+    await consentContractHandle
+      .setTrustedForwarder(trustedforwarder)
       .then((txresponse) => {
         return txresponse.wait();
       })
@@ -119,16 +226,18 @@ task("checkOwnerOf", "Check balance of user")
     const consentContractHandle = new hre.ethers.Contract(
       contractaddress,
       CC().abi,
-      provider
+      provider,
     );
 
-    await consentContractHandle.ownerOf(tokenid)
-      .then((result) => {
-        console.log("Token belongs to:", result)
-      });
+    await consentContractHandle.ownerOf(tokenid).then((result) => {
+      console.log("Token belongs to:", result);
+    });
   });
 
-task("getConsentContractDomains", "Returns list of URLs associated with a Consent Contract.")
+task(
+  "getConsentContractDomains",
+  "Returns list of URLs associated with a Consent Contract.",
+)
   .addParam("address", "address of the consent contract")
   .setAction(async (taskArgs) => {
     const address = taskArgs.address;
@@ -137,19 +246,21 @@ task("getConsentContractDomains", "Returns list of URLs associated with a Consen
     const consentContractHandle = new hre.ethers.Contract(
       address,
       CC().abi,
-      provider
+      provider,
     );
 
-    await consentContractHandle.getDomains()
-      .then((urls) => {
-        console.log("Registered URLS:", urls)
-      });
+    await consentContractHandle.getDomains().then((urls) => {
+      console.log("Registered URLS:", urls);
+    });
   });
 
 task("addConsentContractDomain", "Add a new URL to a Consent Contract.")
   .addParam("address", "address of the consent contract")
   .addParam("url", "URL to add to the Consent Contract")
-  .addParam("accountnumber", "integer referencing the account to you in the configured HD Wallet")
+  .addParam(
+    "accountnumber",
+    "integer referencing the account to you in the configured HD Wallet",
+  )
   .setAction(async (taskArgs) => {
     const address = taskArgs.address;
     const url = taskArgs.url;
@@ -160,14 +271,15 @@ task("addConsentContractDomain", "Add a new URL to a Consent Contract.")
     const consentContractHandle = new hre.ethers.Contract(
       address,
       CC().abi,
-      account
+      account,
     );
 
-    console.log("Is this doing anything?")
+    console.log("Is this doing anything?");
 
-    consentContractHandle.addDomain(url)
+    consentContractHandle
+      .addDomain(url)
       .then((txResponse) => {
-        console.log(txResponse)
+        console.log(txResponse);
         return txResponse.wait();
       })
       .then((txrct) => {
@@ -185,14 +297,19 @@ task("getUserConsentContracts", "Check which constract a user has opted in to.")
     const consentContractFactorHandle = new hre.ethers.Contract(
       consentFactory(),
       CCFactory().abi,
-      provider
+      provider,
     );
 
     await consentContractFactorHandle
       .getUserConsentAddressesCount(useraddress)
       .then((numCCs) => {
-        return consentContractFactorHandle.getUserConsentAddressesByIndex(useraddress, 0, numCCs);
-      }).then((myCCs) => {
+        return consentContractFactorHandle.getUserConsentAddressesByIndex(
+          useraddress,
+          0,
+          numCCs,
+        );
+      })
+      .then((myCCs) => {
         console.log("User is opted into:", myCCs);
       });
   });
@@ -204,7 +321,10 @@ task(
   .addParam("owneraddress", "Target consent address.")
   .addParam("baseuri", "Base uri of the consent contract.")
   .addParam("name", "Name of the consent contract.")
-  .addParam("accountnumber", "integer referencing the account to you in the configured HD Wallet")
+  .addParam(
+    "accountnumber",
+    "integer referencing the account to you in the configured HD Wallet",
+  )
   .setAction(async (taskArgs) => {
     const owner = taskArgs.owneraddress;
     const baseUri = taskArgs.baseuri;
@@ -217,7 +337,7 @@ task(
     const consentFactoryContractHandle = new hre.ethers.Contract(
       consentFactory(),
       CCFactory().abi,
-      account
+      account,
     );
 
     console.log("");
@@ -231,10 +351,14 @@ task(
         logTXDetails(txrct);
       })
       .then(() => {
-        return consentFactoryContractHandle.getUserDeployedConsentsByIndex(taskArgs.owneraddress, 0, 5);
+        return consentFactoryContractHandle.getUserDeployedConsentsByIndex(
+          taskArgs.owneraddress,
+          0,
+          5,
+        );
       })
       .then((myCCs) => {
-        console.log("Concent Contracts owned by this account:", myCCs)
+        console.log("Concent Contracts owned by this account:", myCCs);
       });
   });
 
@@ -244,7 +368,10 @@ task(
 )
   .addParam("consentaddress", "Target consent address.")
   .addParam("cid", "IPFS multihash of SDQL query.")
-  .addParam("accountnumber", "integer referencing the account to you in the configured HD Wallet")
+  .addParam(
+    "accountnumber",
+    "integer referencing the account to you in the configured HD Wallet",
+  )
   .setAction(async (taskArgs) => {
     const multihash = taskArgs.cid;
     const accountnumber = taskArgs.accountnumber;
@@ -255,16 +382,17 @@ task(
     const consentContractHandle = new hre.ethers.Contract(
       taskArgs.consentaddress,
       CC().abi,
-      account
+      account,
     );
 
-    await consentContractHandle.requestForData(multihash)
+    await consentContractHandle
+      .requestForData(multihash)
       .then((txResponse) => {
         return txResponse.wait();
       })
       .then((txrct) => {
         logTXDetails(txrct);
-      })
+      });
   });
 
 task("checkConsentContractByRole", "")
@@ -277,47 +405,79 @@ task("checkConsentContractByRole", "")
     const consentFactoryContractHandle = new hre.ethers.Contract(
       consentFactory(),
       CCFactory().abi,
-      provider
+      provider,
     );
 
     // Construct the Role byte arrays
-    const DEFAULT_ADMIN_ROLE = hre.ethers.utils.keccak256(hre.ethers.utils.toUtf8Bytes("0"));
-    const PAUSER_ROLE = hre.ethers.utils.keccak256(hre.ethers.utils.toUtf8Bytes("PAUSER_ROLE"));
-    const SIGNER_ROLE = hre.ethers.utils.keccak256(hre.ethers.utils.toUtf8Bytes("SIGNER_ROLE"));
-    const REQUESTER_ROLE = hre.ethers.utils.keccak256(hre.ethers.utils.toUtf8Bytes("REQUESTER_ROLE"));
+    const DEFAULT_ADMIN_ROLE = hre.ethers.utils.keccak256(
+      hre.ethers.utils.toUtf8Bytes("0"),
+    );
+    const PAUSER_ROLE = hre.ethers.utils.keccak256(
+      hre.ethers.utils.toUtf8Bytes("PAUSER_ROLE"),
+    );
+    const SIGNER_ROLE = hre.ethers.utils.keccak256(
+      hre.ethers.utils.toUtf8Bytes("SIGNER_ROLE"),
+    );
+    const REQUESTER_ROLE = hre.ethers.utils.keccak256(
+      hre.ethers.utils.toUtf8Bytes("REQUESTER_ROLE"),
+    );
 
     // Query the roles
-    await consentFactoryContractHandle.getUserRoleAddressesCount(owneraddress, DEFAULT_ADMIN_ROLE)
+    await consentFactoryContractHandle
+      .getUserRoleAddressesCount(owneraddress, DEFAULT_ADMIN_ROLE)
       .then((DACount) => {
-        return consentFactoryContractHandle.getUserRoleAddressesCountByIndex(owneraddress, DEFAULT_ADMIN_ROLE, 0, DACount)
+        return consentFactoryContractHandle.getUserRoleAddressesCountByIndex(
+          owneraddress,
+          DEFAULT_ADMIN_ROLE,
+          0,
+          DACount,
+        );
       })
       .then((DAList) => {
-        console.log("DEFAULT_ADMIN_ROLE Membership:", DAList)
-      })
+        console.log("DEFAULT_ADMIN_ROLE Membership:", DAList);
+      });
 
-    await consentFactoryContractHandle.getUserRoleAddressesCount(owneraddress, PAUSER_ROLE)
+    await consentFactoryContractHandle
+      .getUserRoleAddressesCount(owneraddress, PAUSER_ROLE)
       .then((DACount) => {
-        return consentFactoryContractHandle.getUserRoleAddressesCountByIndex(owneraddress, PAUSER_ROLE, 0, DACount)
+        return consentFactoryContractHandle.getUserRoleAddressesCountByIndex(
+          owneraddress,
+          PAUSER_ROLE,
+          0,
+          DACount,
+        );
       })
       .then((DAList) => {
-        console.log("PAUSER_ROLE Membership:", DAList)
-      })
+        console.log("PAUSER_ROLE Membership:", DAList);
+      });
 
-    await consentFactoryContractHandle.getUserRoleAddressesCount(owneraddress, SIGNER_ROLE)
+    await consentFactoryContractHandle
+      .getUserRoleAddressesCount(owneraddress, SIGNER_ROLE)
       .then((DACount) => {
-        return consentFactoryContractHandle.getUserRoleAddressesCountByIndex(owneraddress, SIGNER_ROLE, 0, DACount)
+        return consentFactoryContractHandle.getUserRoleAddressesCountByIndex(
+          owneraddress,
+          SIGNER_ROLE,
+          0,
+          DACount,
+        );
       })
       .then((DAList) => {
-        console.log("SIGNER_ROLE Membership:", DAList)
-      })
+        console.log("SIGNER_ROLE Membership:", DAList);
+      });
 
-    await consentFactoryContractHandle.getUserRoleAddressesCount(owneraddress, REQUESTER_ROLE)
+    await consentFactoryContractHandle
+      .getUserRoleAddressesCount(owneraddress, REQUESTER_ROLE)
       .then((DACount) => {
-        return consentFactoryContractHandle.getUserRoleAddressesCountByIndex(owneraddress, REQUESTER_ROLE, 0, DACount)
+        return consentFactoryContractHandle.getUserRoleAddressesCountByIndex(
+          owneraddress,
+          REQUESTER_ROLE,
+          0,
+          DACount,
+        );
       })
       .then((DAList) => {
-        console.log("REQUESTER_ROLE Membership:", DAList)
-      })
+        console.log("REQUESTER_ROLE Membership:", DAList);
+      });
   });
 
 task(
@@ -334,27 +494,26 @@ task(
     const consentContractHandle = new hre.ethers.Contract(
       taskArgs.consentaddress,
       CC().abi,
-      provider
+      provider,
     );
 
     // declare the filter parameters of the event of interest
     const filter = await consentContractHandle.filters.RequestForData(
       taskArgs.owneraddress,
-    )
+    );
 
-    await consentContractHandle.queryFilter(filter)
-      .then((result) => {
+    await consentContractHandle.queryFilter(filter).then((result) => {
+      console.log("");
+      console.log("Queried address:", consentAddress);
+      // print each event's arguments
+      result.forEach((log, index) => {
         console.log("");
-        console.log("Queried address:", consentAddress);
-        // print each event's arguments
-        result.forEach((log, index) => {
-          console.log("");
-          console.log("Request number: ", index + 1);
-          console.log("  Owner address: ", log.args.requester);
-          console.log("  Requested CID:", log.args.ipfsCID);
-        });
-        console.log("");
+        console.log("Request number: ", index + 1);
+        console.log("  Owner address: ", log.args.requester);
+        console.log("  Requested CID:", log.args.ipfsCID);
       });
+      console.log("");
+    });
   });
 
 task(
@@ -380,23 +539,22 @@ task(
     );
 
     // generate log with query's results
-    await consentContractHandle.queryFilter(filter)
-      .then((result) => {
-        console.log(result);
+    await consentContractHandle.queryFilter(filter).then((result) => {
+      console.log(result);
 
+      console.log("");
+      console.log("Queried address:", taskArgs.consentaddress);
+
+      // print each event's arguments
+      result.forEach((log, index) => {
         console.log("");
-        console.log("Queried address:", taskArgs.consentaddress);
-
-        // print each event's arguments
-        result.forEach((log, index) => {
-          console.log("");
-          console.log("Request number: ", index + 1);
-          console.log("  Owner address: ", log.args.requester);
-          console.log("  Requested CID:", log.args.ipfsCID);
-        });
-
-        console.log("");
+        console.log("Request number: ", index + 1);
+        console.log("  Owner address: ", log.args.requester);
+        console.log("  Requested CID:", log.args.ipfsCID);
       });
+
+      console.log("");
+    });
   });
 
 // Task to revoke roles on consent contract
@@ -408,7 +566,10 @@ task("grantRole", "Grant specific role on the consent contract.")
   .addParam("consentaddress", "Target consent address.")
   .addParam("grantee", "Address to grant role to.")
   .addParam("role", "Role to grant")
-  .addParam("accountnumber", "integer referencing the account to you in the configured HD Wallet")
+  .addParam(
+    "accountnumber",
+    "integer referencing the account to you in the configured HD Wallet",
+  )
   .setAction(async (taskArgs) => {
     const accountnumber = taskArgs.accountnumber;
     const accounts = hre.ethers.getSigners();
@@ -418,15 +579,15 @@ task("grantRole", "Grant specific role on the consent contract.")
     const grantee = taskArgs.grantee;
     const consentaddress = taskArgs.consentaddress;
 
-
     // attach the first signer account to the consent contract handle
     const consentContractHandle = new hre.ethers.Contract(
       consentaddress,
       CC().abi,
-      account
+      account,
     );
 
-    await consentContractHandle.grantRole(roleBytes, grantee)
+    await consentContractHandle
+      .grantRole(roleBytes, grantee)
       .then((txResponse) => {
         return txResponse.wait();
       })
@@ -444,7 +605,10 @@ task("revokeRole", "Revokes a specific role on the consent contract.")
   .addParam("consentaddress", "Target consent address.")
   .addParam("revokee", "Address to revoke role from.")
   .addParam("role", "Role to grant")
-  .addParam("accountnumber", "integer referencing the account to you in the configured HD Wallet")
+  .addParam(
+    "accountnumber",
+    "integer referencing the account to you in the configured HD Wallet",
+  )
   .setAction(async (taskArgs) => {
     const accountnumber = taskArgs.accountnumber;
     const accounts = hre.ethers.getSigners();
@@ -454,15 +618,15 @@ task("revokeRole", "Revokes a specific role on the consent contract.")
     const revokee = taskArgs.revokee;
     const consentaddress = taskArgs.consentaddress;
 
-
     // attach the first signer account to the consent contract handle
     const consentContractHandle = new hre.ethers.Contract(
       consentaddress,
       CC().abi,
-      account
+      account,
     );
 
-    await consentContractHandle.revokeRole(roleBytes, revokee)
+    await consentContractHandle
+      .revokeRole(roleBytes, revokee)
       .then((txResponse) => {
         return txResponse.wait();
       })

--- a/packages/contracts/tasks/constants.js
+++ b/packages/contracts/tasks/constants.js
@@ -7,6 +7,15 @@ const logTXDetails = (txrct) => {
   console.log("Gas Used:", txrct.gasUsed.toString());
 };
 
+const BEACON = function () {
+  const artifactPath = "./artifacts/\@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol/UpgradeableBeacon.json";
+  if (fs.existsSync(artifactPath)) {
+    return require("../" + artifactPath);
+  } else {
+    return null;
+  }
+};
+
 // dynamic artifact imports to prevent error when contracts are not compiled
 const CC = function () {
   const artifactPath = "./artifacts/contracts/consent/Consent.sol/Consent.json";
@@ -61,6 +70,36 @@ const gasSettings = async function (txCount) {
     };
   }
   return gs;
+};
+
+// returns deployment address of the Consent Contract Beacon Contract
+const consentBeacon = function () {
+  const hre = require("hardhat");
+  if (hre.hardhatArguments.network == "dev") {
+    return "";
+  } else if (hre.hardhatArguments.network == "localhost") {
+    return "";
+  } else if (hre.hardhatArguments.network == "doodle") {
+    return "";
+  } else if (hre.hardhatArguments.network == "hardhat") {
+    return "";
+  } else if (hre.hardhatArguments.network == "rinkeby") {
+    return "";
+  } else if (hre.hardhatArguments.network == "mumbai") {
+    return "";
+  } else if (hre.hardhatArguments.network == "polygon") {
+    return "";
+  } else if (hre.hardhatArguments.network == "fuji") {
+    return "0xaF5Df6017f28486647b1B621412cCf556E2c5860";
+  } else if (hre.hardhatArguments.network == "avalanche") {
+    return "";
+  } else if (hre.hardhatArguments.network == "fantom") {
+    return "";
+  } else if (hre.hardhatArguments.network == "mainnet") {
+    return "";
+  } else {
+    return "";
+  }
 };
 
 // returns deployment address of the Consent Contract Factory
@@ -164,10 +203,12 @@ const countryCode = function () {
 
 module.exports = {
   logTXDetails,
+  BEACON,
   CC,
   CCFactory,
   CR,
   SIFT,
+  consentBeacon,
   consentFactory,
   gasSettings,
   countryCode,


### PR DESCRIPTION
This PR corrects the trusted forwarder address in Consent.sol. However, a better solution to setting the trustedForwarder address on initial deployment that is more automatic still needs to be implemented and tested. 