### PR TITLE
fixed SDQLQueryRepository

### DIFF
--- a/packages/core/src/implementations/data/SDQLQueryRepository.ts
+++ b/packages/core/src/implementations/data/SDQLQueryRepository.ts
@@ -55,7 +55,7 @@ export class SDQLQueryRepository implements ISDQLQueryRepository {
         }
 
         // Create the query
-        const query = new SDQLQuery(cid, sdql);
+        const query = new SDQLQuery(cid, SDQLString(JSON.stringify(sdql)));
 
         // Cache the query
         this.queryCache.set(cid, query);

--- a/packages/core/src/interfaces/objects/SDQL/SDQLSchema.ts
+++ b/packages/core/src/interfaces/objects/SDQL/SDQLSchema.ts
@@ -12,12 +12,14 @@ export class SDQLSchema {
    * A object created from string
    */
 
-  constructor(readonly internalObj: ISDQLQueryObject) {}
+  constructor(readonly internalObj: ISDQLQueryObject) {
+    // console.log("internalObj: " + internalObj)
+  }
 
   static fromString(s: SDQLString): SDQLSchema {
     //console.log("S: ", s)
     //const obj = JSON.parse(s);
-    return new SDQLSchema(JSON.parse(s));
+    return new SDQLSchema(JSON.parse(s)  as ISDQLQueryObject);
   }
 
   public get version(): string {


### PR DESCRIPTION
reading the query from IPFS is converting the string to object (not sure why it started doing that recently). Converted the object back to SDQLString in the repository