### PR TITLE
Seed the Sift registry in the Hardhat node deploy

### DIFF
--- a/packages/contracts/scripts/deployment.js
+++ b/packages/contracts/scripts/deployment.js
@@ -5,6 +5,7 @@
 // Runtime Environment's members available in the global scope.
 const hre = require("hardhat");
 const { ethers, upgrades } = require("hardhat");
+const { logTXDetails } = require("../tasks/constants.js");
 
 // declare variables that need to be referenced by other functions
 let accounts;
@@ -170,6 +171,22 @@ async function deploySift() {
 
   console.log("Sift deployed to:", sift.address);
   console.log("Sift Gas Fee:", sift_receipt.gasUsed.toString());
+
+  await sift.verifyURL("snickerdoodle.com", accounts[0].address)
+  .then((txResponse) => {
+    return txResponse.wait();
+  })
+  .then((txrct) => {
+    logTXDetails(txrct);
+  });
+
+  await sift.maliciousURL("webthree.love", accounts[0].address)
+  .then((txResponse) => {
+    return txResponse.wait();
+  })
+  .then((txrct) => {
+    logTXDetails(txrct);
+  });
 }
 
 async function deployMinimalForwarder() {


### PR DESCRIPTION
This is a very small update to `deployment.js` in the contracts package. The modification simple adds two sites to the 
Sift registry: 

`snickerdoodle.com` as a verified URL
`webthree.love` as a malicious URL

So that QA can test scam filter on the develop environment. 