### PR TITLE
Fixed chain id and added sass and gulp dev dependencies

### DIFF
--- a/packages/browserExtension/package.json
+++ b/packages/browserExtension/package.json
@@ -52,9 +52,5 @@
     "tldts": "^5.7.89",
     "uuid": "^8.3.2",
     "webextension-polyfill": "^0.9.0"
-  },
-  "devDependencies": {
-    "gulp-sass": "^5.1.0",
-    "sass": "^1.55.0"
   }
 }


### PR DESCRIPTION
Updated chain id replacing 42 with 5 and added sass and gulp dev dependencies which Mac m1 users need.