### PR TITLE
[ENGT-1091] Put found opt in tokens into Persistence + more

### DIFF
--- a/packages/core/src/implementations/api/BlockchainListener.ts
+++ b/packages/core/src/implementations/api/BlockchainListener.ts
@@ -85,16 +85,26 @@ export class BlockchainListener implements IBlockchainListener {
      */
     this.logUtils.debug("Initializing Blockchain Listener");
 
-    return ResultUtils.combine([this.configProvider.getConfig()]).map(
-      ([config]) => {
-        setInterval(() => {
-          this.controlChainBlockMined(config).mapErr((e) => {
-            console.error(e);
-            return e;
-          });
-        }, config.requestForDataCheckingFrequency);
-      },
-    );
+    return ResultUtils.combine([
+      this.configProvider.getConfig(),
+      this.contextProvider.getContext(),
+    ]).map(([config, context]) => {
+      // Start polling
+      setInterval(() => {
+        this.controlChainBlockMined(config).mapErr((e) => {
+          this.logUtils.error(e);
+          return e;
+        });
+      }, config.requestForDataCheckingFrequency);
+
+      // Subscribe to the opt-in event, and immediately do a poll
+      context.publicEvents.onCohortJoined.subscribe(() => {
+        this.controlChainBlockMined(config).mapErr((e) => {
+          this.logUtils.error(e);
+          return e;
+        });
+      });
+    });
   }
 
   protected controlChainBlockMined(

--- a/packages/core/src/implementations/business/utilities/ConsentTokenUtils.ts
+++ b/packages/core/src/implementations/business/utilities/ConsentTokenUtils.ts
@@ -28,6 +28,8 @@ export class ConsentTokenUtils {
     protected consentRepo: IConsentContractRepository,
   ) {}
 
+  // This is nearly identical to ConsentContractRepo.getConsentToken, but does the lookup
+  // of accepted invites for you.
   public getCurrentConsentToken(
     consentContractAddress: EVMContractAddress,
   ): ResultAsync<


### PR DESCRIPTION
Update persistence if we find an opt-in token on chain when checking invitation status. Add the invitation to peristence if you find it.

This will also immediately do a poll for events after opting in to a consent contract, so you don't have to wait for a poll period and can get your reward immediately.