### PR TITLE
upgrade to consent factory to add new methods

### DIFF
--- a/packages/contracts/.openzeppelin/avalanche-fuji.json
+++ b/packages/contracts/.openzeppelin/avalanche-fuji.json
@@ -442,6 +442,332 @@
           }
         }
       }
+    },
+    "a553fcf188c34ff6bac51f08fb96439a989d6b71fc4bb4bfb562769f8955045e": {
+      "address": "0xa8Bb75dDc1207198Fc1fE6440563913eA5D2Aa4A",
+      "txHash": "0x5c7c37e1f42bc3ff1ca9089f0dec2f84fcbaf5c2fb5c65e37a4acf6b93668c9a",
+      "layout": {
+        "solcVersion": "0.8.9",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)179_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_roleMembers",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_mapping(t_bytes32,t_struct(AddressSet)4164_storage)",
+            "contract": "AccessControlEnumerableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlEnumerableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol:76"
+          },
+          {
+            "label": "listingsHead",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_uint256",
+            "contract": "ConsentFactory",
+            "src": "contracts/consent/ConsentFactory.sol:28"
+          },
+          {
+            "label": "listingsTotal",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_uint256",
+            "contract": "ConsentFactory",
+            "src": "contracts/consent/ConsentFactory.sol:31"
+          },
+          {
+            "label": "listings",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_mapping(t_uint256,t_struct(Listing)6580_storage)",
+            "contract": "ConsentFactory",
+            "src": "contracts/consent/ConsentFactory.sol:34"
+          },
+          {
+            "label": "trustedForwarder",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_address",
+            "contract": "ConsentFactory",
+            "src": "contracts/consent/ConsentFactory.sol:40"
+          },
+          {
+            "label": "addressToDeployedConsents",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_mapping(t_address,t_array(t_address)dyn_storage)",
+            "contract": "ConsentFactory",
+            "src": "contracts/consent/ConsentFactory.sol:43"
+          },
+          {
+            "label": "addressToDeployedConsentsIndex",
+            "offset": 0,
+            "slot": "256",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ConsentFactory",
+            "src": "contracts/consent/ConsentFactory.sol:46"
+          },
+          {
+            "label": "consentAddressCheck",
+            "offset": 0,
+            "slot": "257",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "ConsentFactory",
+            "src": "contracts/consent/ConsentFactory.sol:49"
+          },
+          {
+            "label": "addressToUserRolesArray",
+            "offset": 0,
+            "slot": "258",
+            "type": "t_mapping(t_address,t_mapping(t_bytes32,t_array(t_address)dyn_storage))",
+            "contract": "ConsentFactory",
+            "src": "contracts/consent/ConsentFactory.sol:53"
+          },
+          {
+            "label": "addressToUserRolesArrayIndex",
+            "offset": 0,
+            "slot": "259",
+            "type": "t_mapping(t_address,t_mapping(t_bytes32,t_mapping(t_address,t_uint256)))",
+            "contract": "ConsentFactory",
+            "src": "contracts/consent/ConsentFactory.sol:57"
+          },
+          {
+            "label": "beaconAddress",
+            "offset": 0,
+            "slot": "260",
+            "type": "t_address",
+            "contract": "ConsentFactory",
+            "src": "contracts/consent/ConsentFactory.sol:60"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_array(t_address)dyn_storage)": {
+            "label": "mapping(address => address[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_array(t_address)dyn_storage))": {
+            "label": "mapping(address => mapping(bytes32 => address[]))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_mapping(t_address,t_uint256)))": {
+            "label": "mapping(address => mapping(bytes32 => mapping(address => uint256)))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_array(t_address)dyn_storage)": {
+            "label": "mapping(bytes32 => address[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(bytes32 => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(AddressSet)4164_storage)": {
+            "label": "mapping(bytes32 => struct EnumerableSetUpgradeable.AddressSet)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)179_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Listing)6580_storage)": {
+            "label": "mapping(uint256 => struct ConsentFactory.Listing)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AddressSet)4164_storage": {
+            "label": "struct EnumerableSetUpgradeable.AddressSet",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)3849_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Listing)6580_storage": {
+            "label": "struct ConsentFactory.Listing",
+            "members": [
+              {
+                "label": "next",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "cid",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(RoleData)179_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Set)3849_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/packages/contracts/contracts/consent/ConsentFactory.sol
+++ b/packages/contracts/contracts/consent/ConsentFactory.sol
@@ -127,6 +127,23 @@ contract ConsentFactory is Initializable, PausableUpgradeable, AccessControlEnum
         listingsTotal += 1; 
     }
 
+    /// @notice Removes a listing behind the head element of the marketplace list
+    /// @dev _upstream -> _oldSlot -> _downstream
+    /// @param _upstream upstream pointer that will point to _newSlot  
+    function removeListingTail(uint256 _upstream) public onlyRole(DEFAULT_ADMIN_ROLE) {
+
+        require(listings[_upstream].next > 1, "ConsentFactory: invalid upstream slot");
+
+        // point upstream to the next slot
+        uint256 oldSlot = listings[_upstream].next;
+        listings[_upstream].next = listings[oldSlot].next;
+        
+        // delete the old slot pointed to my _upstream
+        delete listings[oldSlot];
+
+        listingsTotal -= 1; 
+    }
+
     /// @notice Creates a new head listing in the marketplace listing map
     /// @dev _newSlot -> oldHeadSlot
     /// @param _newHead Downstream pointer that will be pointed to by _newSlot
@@ -143,6 +160,21 @@ contract ConsentFactory is Initializable, PausableUpgradeable, AccessControlEnum
         listingsHead = _newHead;
 
         listingsTotal += 1; 
+    }
+
+    /// @notice Removes the head listing of the marketplace
+    /// @dev oldHead -> newHead
+    function removeHeadListing() public onlyRole(DEFAULT_ADMIN_ROLE) {
+
+        require(listingsHead > 1, "ConsentFactory: no head listing to remove");
+
+        // cache the slot for the new head listing and delete the old head listing
+        uint256 newHeadSlot = listings[listingsHead].next;
+        delete listings[listingsHead];
+
+        // update the new head listing and decriment the total listings count
+        listingsHead = newHeadSlot;
+        listingsTotal -= 1; 
     }
 
     /// @notice Returns an array of cids from the marketplace linked list and the next active slot for pagination

--- a/packages/contracts/scripts/consent-factory-upgrade.js
+++ b/packages/contracts/scripts/consent-factory-upgrade.js
@@ -1,0 +1,38 @@
+// We require the Hardhat Runtime Environment explicitly here. This is optional
+// but useful for running the script in a standalone fashion through `node <script>`.
+//
+// When running the script with `npx hardhat run <script>` you'll find the Hardhat
+// Runtime Environment's members available in the global scope.
+const { ethers, upgrades } = require("hardhat");
+
+// function to deploy the Consent Factory contract
+async function upgradeConsentFactory() {
+  console.log("");
+  console.log("Deploying Consent Factory contract...");
+
+  const ConsentFactory = await ethers.getContractFactory("ConsentFactory");
+
+  // the Consent Factory contract requires one argument on deployment:
+  // the address of the trusted forwarder who will pay for the meta tx fees
+  const upgradedConsentFactory = await upgrades.upgradeProxy("0x2231A160C7a7bba5a9dDbaF6a44A7EF76Ef74C77", ConsentFactory);
+
+  console.log("ConsentFactory upgraded:", upgradedConsentFactory);
+}
+
+// function that runs the full deployment of all contracts
+async function fullDeployment() {
+  await upgradeConsentFactory();
+
+  console.log("");
+  console.log("Full deployment successful!");
+  console.log("");
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+fullDeployment()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/packages/contracts/tasks/consent.js
+++ b/packages/contracts/tasks/consent.js
@@ -518,6 +518,35 @@ task("addTopMarketplaceListing", "Add a new marketplace listing to top slot")
       });
   });
 
+  task("removeMarketplaceTailListing", "Removes a non-head listing from the marketplace")
+  .addParam("upstreamslot", "Integer number for the slot which points to the listing to be removed.")
+  .addParam(
+    "accountnumber",
+    "integer referencing the account to use in the configured HD Wallet",
+  )
+  .setAction(async (taskArgs) => {
+    const upstreamslot = taskArgs.upstreamslot;
+    const accountnumber = taskArgs.accountnumber;
+    const accounts = await hre.ethers.getSigners();
+    const account = accounts[accountnumber];
+
+    // attach the first signer account to the consent contract handle
+    const consentFactoryContractHandle = new hre.ethers.Contract(
+      consentFactory(),
+      CCFactory().abi,
+      account,
+    );
+
+    await consentFactoryContractHandle
+      .removeListingTail(upstreamslot)
+      .then((txResponse) => {
+        return txResponse.wait();
+      })
+      .then((txrct) => {
+        logTXDetails(txrct);
+      });
+  });
+
 task(
   "createConsentContract",
   "Calls the consent factory and deploys a Consent contract",


### PR DESCRIPTION
Needed to upgrade ConsentFactory.sol on the Fuji network to introduce methods for removing a marketplace listing. 