### PR TITLE
Fail gracefully on invalid schemas in backup restore

### DIFF
--- a/packages/persistence/src/backup/BackupManager.ts
+++ b/packages/persistence/src/backup/BackupManager.ts
@@ -260,6 +260,16 @@ export class BackupManager implements IBackupManager {
                 return ResultUtils.combine(
                   Object.keys(unpacked.records).map((tableName) => {
                     const table = unpacked.records[tableName];
+                    // fail gracefully if invalid table is found in the chunk
+                    if (!this.schemas.has(tableName)) {
+                      console.error(
+                        "invalid table found in backup chunk",
+                        tableName,
+                        backup.header.hash,
+                      );
+                      return okAsync(undefined);
+                    }
+
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                     const migrator = this.schemas.get(tableName)!.migrator;
 


### PR DESCRIPTION
### Release Notes
[JIRA Link](https://snickerdoodlelabs.atlassian.net/browse/ENGT-1422)

### Minor Change
Recently an old build in the production environment caused SD_CoinInfo backups to leak into the production bucket, which caused issues with the newest build. This change fixes that by ignoring table backups not in the schema.

### Pre-Flight Checks
- [ ] Has QA approved this change for dev?
- [ ] Are all unit tests passing?
- [ ] Have you added this description to this week's [release notes](https://drive.google.com/drive/folders/1ELnyVZHgISIlwDQXgy0mb-4qsn_1PRZr?usp=sharing)?
