### PR TITLE
Fix: Delete Slash on api call urls if exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ packages/test-harness/data/insight/*
 # Don't checkin the ceramic stuff
 .ceramic/logs/*
 .ceramic/statestore/*
+
+# Mobile
+packages/mobile/ios/Pods

--- a/packages/common-utils/src/implementations/AxiosAjaxUtils.ts
+++ b/packages/common-utils/src/implementations/AxiosAjaxUtils.ts
@@ -31,7 +31,7 @@ export class AxiosAjaxUtils implements IAxiosAjaxUtils {
 
   public get<T>(url: URL, config?: IRequestConfig): ResultAsync<T, AjaxError> {
     return ResultAsync.fromPromise(
-      this.instance.get(url.toString(), config),
+      this.instance.get(this.stripTrailingSlash(url.toString()), config),
       (e) => new AjaxError(`Unable to get ${url}`, e),
     ).map((response: AxiosResponse<T>) => {
       return response.data;
@@ -50,7 +50,7 @@ export class AxiosAjaxUtils implements IAxiosAjaxUtils {
     config?: IRequestConfig,
   ): ResultAsync<T, AjaxError> {
     return ResultAsync.fromPromise(
-      this.instance.post(url.toString(), data, config),
+      this.instance.post(this.stripTrailingSlash(url.toString()), data, config),
       (e) => new AjaxError(`Unable to post ${url}`, e),
     ).map((response: AxiosResponse<T>) => {
       return response.data;
@@ -69,7 +69,7 @@ export class AxiosAjaxUtils implements IAxiosAjaxUtils {
     config?: IRequestConfig,
   ): ResultAsync<T, AjaxError> {
     return ResultAsync.fromPromise(
-      this.instance.put(url.toString(), data, config),
+      this.instance.put(this.stripTrailingSlash(url.toString()), data, config),
       (e) => new AjaxError(`Unable to put ${url}`, e),
     ).map((response: AxiosResponse<T>) => {
       return response.data;
@@ -81,7 +81,7 @@ export class AxiosAjaxUtils implements IAxiosAjaxUtils {
     config?: IRequestConfig,
   ): ResultAsync<T, AjaxError> {
     return ResultAsync.fromPromise(
-      this.instance.delete(url.toString(), config),
+      this.instance.delete(this.stripTrailingSlash(url.toString()), config),
       (e) => new AjaxError(`Unable to delete ${url}`, e),
     ).map((response: AxiosResponse<T>) => {
       return response.data;
@@ -92,5 +92,9 @@ export class AxiosAjaxUtils implements IAxiosAjaxUtils {
     this.instance.defaults.headers.common = {
       authorization: `Bearer ${token}`,
     };
+  }
+
+  private stripTrailingSlash(url: string) {
+    return url.endsWith("/") ? url.slice(0, -1) : url;
   }
 }


### PR DESCRIPTION
### Release Notes
[JIRA Link](https://snickerdoodlelabs.atlassian.net/jira/software/projects/ENGT/boards/14?selectedIssue=ENGT-1427)

#### Summary:
When we do an API Call we send URL to AjaxUtils with new URL it generates a '/' end of the url because of that some of the API calls doesn't work.
#### Intended results:
With this change we check if a url has a slash if it exist we delete that.

#### Potential Failures:
- What could possibly go wrong?
- How might those failures present within the application?

#### Relevant Metrics/Indicators:
- Are there any metrics (or indicators) that can prove or disprove the integrity of this change?
- List them here...

#### Testing Notes:
- How has this been tested?

<!---For minor fixes replace with the following --->
<!---### Minor Change
A 1-2 sentence summary on the change. If this requires more detail your change is likely not minor.-->

### Pre-Flight Checks
- [ ] Has QA approved this change for dev?
- [ ] Are all unit tests passing?
- [ ] Have you added this description to this week's [release notes](https://drive.google.com/drive/folders/1ELnyVZHgISIlwDQXgy0mb-4qsn_1PRZr?usp=sharing)?
