### PR TITLE
fix for contract factory and added unit test

### DIFF
--- a/packages/contracts/contracts/consent/ConsentFactory.sol
+++ b/packages/contracts/contracts/consent/ConsentFactory.sol
@@ -169,7 +169,7 @@ contract ConsentFactory is Initializable, PausableUpgradeable, AccessControlEnum
         require(existingListing.next < _newSlot, "ConsentFactory: _newSlot is less than existingListing.next");
         
         listings[LLKey][_existingSlot].next = _newSlot;
-        listings[LLKey][_newSlot] = Listing(existingListing.next, _existingSlot, msg.sender, block.timestamp + listingDuration);
+        listings[LLKey][_newSlot] = Listing(_existingSlot, existingListing.next, msg.sender, block.timestamp + listingDuration);
         listings[LLKey][existingListing.next].previous = _newSlot;
 
         listingTotals[LLKey] += 1; 


### PR DESCRIPTION
This PR includes a fix for `insertDownstream()` in the ConsentFactory contract. 

The new slot to be inserted's `previous` value should be the _existingSlot and its `next` should be the `existingListing.next` value. 

![Screenshot 2023-03-29 at 4 22 57 PM](https://user-images.githubusercontent.com/99375214/228472589-344236c0-cd2c-4883-adc7-a736eb25f3f0.png)


Also added unit test for listing getters to catch this. 