### PR TITLE
Found some cases where indexers return invalid values

### DIFF
--- a/packages/core/src/implementations/data/PortfolioBalanceRepository.ts
+++ b/packages/core/src/implementations/data/PortfolioBalanceRepository.ts
@@ -20,12 +20,14 @@ import {
   IAccountBalancesType,
   IAccountNFTs,
   IAccountNFTsType,
+  BigNumberString,
 } from "@snickerdoodlelabs/objects";
 import {
   IPersistenceConfigProvider,
   IPersistenceConfigProviderType,
   PortfolioCache,
 } from "@snickerdoodlelabs/persistence";
+import { BigNumber } from "ethers";
 import { inject, injectable } from "inversify";
 import { errAsync, okAsync, ResultAsync } from "neverthrow";
 import { ResultUtils } from "neverthrow-result-utils";
@@ -236,6 +238,20 @@ export class PortfolioBalanceRepository implements IPortfolioBalanceRepository {
           e,
         );
         return okAsync([]);
+      })
+      .map((tokenBalances) => {
+        // Apprently the tokenBalance.balance can return as in invalid
+        // BigNumber (blank or null), so we'll just correct any possible issue
+        // here.
+        return tokenBalances.map((tokenBalance) => {
+          try {
+            BigNumber.from(tokenBalance.balance);
+          } catch (e) {
+            // Can't convert to bignumber, set it to 0
+            tokenBalance.balance = BigNumberString("0");
+          }
+          return tokenBalance;
+        });
       });
   }
 


### PR DESCRIPTION
### Minor Change
This adds a sanity check when we are creating TokenBalance objects. The APIs that the indexers rely on are inconsistent in ways that aren't documented; they can apparently return invalid balances, which then cause weird errors down the line. This just adds a generic sanity check at the repo layer, that will fix invalid balances to be 0.