### PR TITLE
Convert Utils to ESM module

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,6 +23,7 @@
     "!dist/test",
     "!dist/tsconfig.tsbuildinfo"
   ],
+  "module": "./dist/index.js",
   "scripts": {
     "alias": "tsc-alias && tsc-alias -p test/tsconfig.json",
     "build": "yarn clean && yarn compile",
@@ -32,6 +33,7 @@
     "test:ci": "NODE_OPTIONS=--experimental-vm-modules npx jest --maxWorkers=50% --coverage --passWithNoTests",
     "test:watch": "jest --watch --color --detectOpenHandles"
   },
+  "type": "module",
   "types": "dist/index.d.ts",
   "dependencies": {
     "@snickerdoodlelabs/common-utils": "workspace:^",

--- a/packages/utils/src/ChromeStorageUtils.ts
+++ b/packages/utils/src/ChromeStorageUtils.ts
@@ -1,7 +1,7 @@
 import { PersistenceError } from "@snickerdoodlelabs/objects";
 import { ResultAsync } from "neverthrow";
 
-import { IStorageUtils } from "@utils/IStorageUtils";
+import { IStorageUtils } from "@utils/IStorageUtils.js";
 
 export class ChromeStorageUtils implements IStorageUtils {
   public remove<T = any>(

--- a/packages/utils/src/LocalStorageUtils.ts
+++ b/packages/utils/src/LocalStorageUtils.ts
@@ -3,7 +3,7 @@ import { PersistenceError } from "@snickerdoodlelabs/objects";
 import { injectable } from "inversify";
 import { okAsync, ResultAsync } from "neverthrow";
 
-import { IStorageUtils } from "@utils/IStorageUtils";
+import { IStorageUtils } from "@utils/IStorageUtils.js";
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 interface Dictionary<T> {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,3 @@
-export * from "@utils/ChromeStorageUtils";
-export * from "@utils/LocalStorageUtils";
-export * from "@utils/IStorageUtils";
+export * from "@utils/ChromeStorageUtils.js";
+export * from "@utils/LocalStorageUtils.js";
+export * from "@utils/IStorageUtils.js";

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"outDir": "./dist",
 		"rootDir": "./src",
+		"module": "ES2022",
 		"paths": {
 			"@utils/*": [
 			  "./packages/utils/src/*"


### PR DESCRIPTION
### Minor Change
Converts the "utils" package to an ESM module. Required since this package now depends on common-utils, which is an ESM module.
