### PR TITLE
Non permitted query insights

### DIFF
--- a/packages/core/src/implementations/business/utilities/QueryParsingEngine.ts
+++ b/packages/core/src/implementations/business/utilities/QueryParsingEngine.ts
@@ -310,15 +310,22 @@ export class QueryParsingEngine implements IQueryParsingEngine {
     EvaluationError | QueryFormatError | QueryExpiredError
   > {
     return this.getPermittedQueries(sdqlParser, ast, dataPermissions).andThen(
-      (queries) => {
-        return ResultUtils.combine(this.evalQueries(queries)).map((results) => {
-          return Object.fromEntries(
-            results.map(([queryId, sdqlReturn]) => [
-              queryId,
-              this.SDQLReturnToInsightString(sdqlReturn),
-            ]),
-          ) as IInsightsQueries;
-        });
+      (permittedQueries) => {
+        const allQueries = this.getAllQueriesFromAst(ast);
+
+        return ResultUtils.combine(this.evalQueries(permittedQueries)).map(
+          (results) => {
+            return Object.fromEntries(
+              allQueries.map((query) => {
+                const queryIdentifier = QueryIdentifier(query.name);
+                const sdqlReturn = (results.find(
+                  (result) => result[0] === queryIdentifier,
+                ) || [queryIdentifier, null])[1];
+                return [query.name, this.SDQLReturnToInsight(sdqlReturn)];
+              }),
+            ) as IInsightsQueries;
+          },
+        );
       },
     );
   }
@@ -363,6 +370,8 @@ export class QueryParsingEngine implements IQueryParsingEngine {
     IInsightsReturns,
     EvaluationError | QueryFormatError | QueryExpiredError
   > {
+    const allReturns = [...ast.logic.returns.keys()];
+
     return ResultUtils.combine(
       this.evalReturns(
         ast,
@@ -371,10 +380,13 @@ export class QueryParsingEngine implements IQueryParsingEngine {
       ),
     ).map((results) => {
       return Object.fromEntries(
-        results.map(([returnExpr, sdqlReturn]) => [
-          returnExpr,
-          this.SDQLReturnToInsightString(sdqlReturn),
-        ]),
+        allReturns.map((returnExpr) => {
+          const sdqlReturn = (results.find(
+            (result) => result[0] === returnExpr,
+          ) || [returnExpr, null])[1];
+
+          return [returnExpr, this.SDQLReturnToInsight(sdqlReturn)];
+        }),
       ) as IInsightsReturns;
     });
   }
@@ -389,13 +401,15 @@ export class QueryParsingEngine implements IQueryParsingEngine {
     });
   }
 
-  protected SDQLReturnToInsightString(sdqlR: SDQL_Return): InsightString {
+  protected SDQLReturnToInsight(
+    sdqlR: SDQL_Return | null,
+  ): InsightString | null {
     const actualTypeData = sdqlR as BaseOf<SDQL_Return>;
 
-    if (typeof actualTypeData == "string") {
+    if (actualTypeData == null) {
+      return null;
+    } else if (typeof actualTypeData == "string") {
       return InsightString(actualTypeData);
-    } else if (actualTypeData == null) {
-      return InsightString("");
     } else {
       return InsightString(JSON.stringify(actualTypeData));
     }

--- a/packages/core/test/unit/QueryParsingEngine.test.ts
+++ b/packages/core/test/unit/QueryParsingEngine.test.ts
@@ -152,9 +152,9 @@ class QueryParsingMocks {
     // td.when(this.snickerDoodleCore.getAge()).thenReturn(okAsync(Age(10)));
     td.when(this.demoDataRepo.getAge()).thenReturn(okAsync(Age(10)));
     td.when(this.demoDataRepo.getLocation()).thenReturn(okAsync(country));
-    td.when(this.browsingDataRepo.getSiteVisitsMap()).thenReturn(
-      okAsync(new Map()),
-    );
+    td.when(
+      this.browsingDataRepo.getSiteVisitsMap(td.matchers.anything()),
+    ).thenReturn(okAsync(new Map()));
     td.when(
       this.transactionRepo.getTransactions(td.matchers.anything()),
     ).thenReturn(okAsync([]));

--- a/packages/objects/src/interfaces/IInsights.ts
+++ b/packages/objects/src/interfaces/IInsights.ts
@@ -1,11 +1,11 @@
 import { InsightString, QueryIdentifier } from "@objects/primitives";
 
 export interface IInsightsQueries {
-  [queryId: QueryIdentifier]: InsightString;
+  [queryId: QueryIdentifier]: InsightString | null;
 }
 
 export interface IInsightsReturns {
-  [returnExpr: string]: InsightString;
+  [returnExpr: string]: InsightString | null;
 }
 export interface IInsights {
   queries: IInsightsQueries;


### PR DESCRIPTION
…with answered queries

### Release Notes
[JIRA Link](https://snickerdoodlelabs.atlassian.net/browse/ENGT-1506)

#### Summary:
Return non-permitted query insights to send them as null alongside the answered ones

#### Intended results:
- Non-permitted query insights will be sent as null insight when sending the insights array to the BE

#### Testing Notes:
- Normal sanity tests focusing on permissions change scenarios.

### Pre-Flight Checks
- [ ] Has QA approved this change for dev?
- [x] Are all unit tests passing?
- [ ] Have you added this description to this week's [release notes](https://drive.google.com/drive/folders/1ELnyVZHgISIlwDQXgy0mb-4qsn_1PRZr?usp=sharing)?
