### PR TITLE
fix how we're passing in overrides

### DIFF
--- a/packages/contracts-sdk/package.json
+++ b/packages/contracts-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snickerdoodlelabs/contracts-sdk",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "description": "SDK for snickerdoodlelabs contracts wrappers",
   "license": "MIT",
   "repository": {

--- a/packages/contracts-sdk/src/implementations/ConsentFactoryContract.ts
+++ b/packages/contracts-sdk/src/implementations/ConsentFactoryContract.ts
@@ -51,12 +51,11 @@ export class ConsentFactoryContract implements IConsentFactoryContract {
     name: ConsentName,
     overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, ConsentFactoryContractError> {
-    return this.writeToContract("createConsent", [
-      ownerAddress,
-      baseUri,
-      name,
+    return this.writeToContract(
+      "createConsent",
+      [ownerAddress, baseUri, name],
       overrides,
-    ]);
+    );
   }
 
   // Gets the count of user's deployed Consents
@@ -226,20 +225,22 @@ export class ConsentFactoryContract implements IConsentFactoryContract {
     listingDuration: number,
     overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, ConsentFactoryContractError> {
-    return this.writeToContract("setListingDuration", [
-      listingDuration,
+    return this.writeToContract(
+      "setListingDuration",
+      [listingDuration],
       overrides,
-    ]);
+    );
   }
 
   public setMaxTagsPerListing(
     maxTagsPerListing: number,
     overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, ConsentFactoryContractError> {
-    return this.writeToContract("setMaxTagsPerListing", [
-      maxTagsPerListing,
+    return this.writeToContract(
+      "setMaxTagsPerListing",
+      [maxTagsPerListing],
       overrides,
-    ]);
+    );
   }
 
   public adminRemoveListing(
@@ -247,11 +248,11 @@ export class ConsentFactoryContract implements IConsentFactoryContract {
     removedSlot: BigNumberString,
     overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, ConsentFactoryContractError> {
-    return this.writeToContract("setMaxTagsPerListing", [
-      tag,
-      removedSlot,
+    return this.writeToContract(
+      "setMaxTagsPerListing",
+      [tag, removedSlot],
       overrides,
-    ]);
+    );
   }
 
   public getListingDetail(
@@ -415,11 +416,12 @@ export class ConsentFactoryContract implements IConsentFactoryContract {
   protected writeToContract(
     functionName: string,
     functionParams: any[],
+    overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, ConsentFactoryContractError> {
     return ResultAsync.fromPromise(
-      this.contract[functionName](
-        ...functionParams,
-      ) as Promise<ethers.providers.TransactionResponse>,
+      this.contract[functionName](...functionParams, {
+        ...overrides,
+      }) as Promise<ethers.providers.TransactionResponse>,
       (e) => {
         return new ConsentFactoryContractError(
           `Unable to call ${functionName}()`,

--- a/packages/contracts-sdk/src/implementations/CrumbsContract.ts
+++ b/packages/contracts-sdk/src/implementations/CrumbsContract.ts
@@ -82,11 +82,7 @@ export class CrumbsContract implements ICrumbsContract {
     tokenUri: TokenUri,
     overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, CrumbsContractError> {
-    return this.writeToContract("createCrumb", [
-      crumbId,
-      tokenUri,
-      overrides,
-    ]);
+    return this.writeToContract("createCrumb", [crumbId, tokenUri], overrides);
   }
 
   public encodeCreateCrumb(
@@ -105,7 +101,7 @@ export class CrumbsContract implements ICrumbsContract {
     crumbId: TokenId,
     overrides?: ContractOverrides | undefined,
   ): ResultAsync<WrappedTransactionResponse, CrumbsContractError> {
-    return this.writeToContract("createCrumb", [crumbId, overrides]);
+    return this.writeToContract("createCrumb", [crumbId], overrides);
   }
 
   public encodeBurnCrumb(crumbId: TokenId): HexString {
@@ -119,11 +115,11 @@ export class CrumbsContract implements ICrumbsContract {
     tokenURI: TokenUri,
     overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, CrumbsContractError> {
-    return this.writeToContract("updateTokenURI", [
-      crumbId,
-      tokenURI,
+    return this.writeToContract(
+      "updateTokenURI",
+      [crumbId, tokenURI],
       overrides,
-    ]);
+    );
   }
 
   public getContract(): ethers.Contract {
@@ -134,11 +130,12 @@ export class CrumbsContract implements ICrumbsContract {
   protected writeToContract(
     functionName: string,
     functionParams: any[],
+    overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, CrumbsContractError> {
     return ResultAsync.fromPromise(
-      this.contract[functionName](
-        ...functionParams,
-      ) as Promise<ethers.providers.TransactionResponse>,
+      this.contract[functionName](...functionParams, {
+        ...overrides,
+      }) as Promise<ethers.providers.TransactionResponse>,
       (e) => {
         return new CrumbsContractError(
           `Unable to call ${functionName}()`,

--- a/packages/contracts-sdk/src/implementations/ERC721RewardContract.ts
+++ b/packages/contracts-sdk/src/implementations/ERC721RewardContract.ts
@@ -248,11 +248,11 @@ export class ERC721RewardContract implements IERC721RewardContract {
     address: EVMAccountAddress,
     overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, ERC721RewardContractError> {
-    return this.writeToContract("grantRole", [
-      ERewardRoles[role],
-      address,
+    return this.writeToContract(
+      "grantRole",
+      [ERewardRoles[role], address],
       overrides,
-    ]);
+    );
   }
 
   public revokeRole(
@@ -260,11 +260,11 @@ export class ERC721RewardContract implements IERC721RewardContract {
     address: EVMAccountAddress,
     overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, ERC721RewardContractError> {
-    return this.writeToContract("revokeRole", [
-      ERewardRoles[role],
-      address,
+    return this.writeToContract(
+      "revokeRole",
+      [ERewardRoles[role], address],
       overrides,
-    ]);
+    );
   }
 
   public renounceRole(
@@ -272,11 +272,11 @@ export class ERC721RewardContract implements IERC721RewardContract {
     address: EVMAccountAddress,
     overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, ERC721RewardContractError> {
-    return this.writeToContract("renounceRole", [
-      ERewardRoles[role],
-      address,
+    return this.writeToContract(
+      "renounceRole",
+      [ERewardRoles[role], address],
       overrides,
-    ]);
+    );
   }
 
   public filters = {
@@ -296,11 +296,12 @@ export class ERC721RewardContract implements IERC721RewardContract {
   protected writeToContract(
     functionName: string,
     functionParams: any[],
+    overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, ERC721RewardContractError> {
     return ResultAsync.fromPromise(
-      this.contract[functionName](
-        ...functionParams,
-      ) as Promise<ethers.providers.TransactionResponse>,
+      this.contract[functionName](...functionParams, {
+        ...overrides,
+      }) as Promise<ethers.providers.TransactionResponse>,
       (e) => {
         return new ERC721RewardContractError(
           `Unable to call ${functionName}()`,

--- a/packages/contracts-sdk/src/implementations/MinimalForwarderContract.ts
+++ b/packages/contracts-sdk/src/implementations/MinimalForwarderContract.ts
@@ -73,7 +73,7 @@ export class MinimalForwarderContract implements IMinimalForwarderContract {
     signature: Signature,
     overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, MinimalForwarderContractError> {
-    return this.writeToContract("execute", [request, signature, overrides]);
+    return this.writeToContract("execute", [request, signature], overrides);
   }
 
   public getContract(): ethers.Contract {
@@ -84,11 +84,12 @@ export class MinimalForwarderContract implements IMinimalForwarderContract {
   protected writeToContract(
     functionName: string,
     functionParams: any[],
+    overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, MinimalForwarderContractError> {
     return ResultAsync.fromPromise(
-      this.contract[functionName](
-        ...functionParams,
-      ) as Promise<ethers.providers.TransactionResponse>,
+      this.contract[functionName](...functionParams, {
+        ...overrides,
+      }) as Promise<ethers.providers.TransactionResponse>,
       (e) => {
         return new MinimalForwarderContractError(
           `Unable to call ${functionName}()`,

--- a/packages/contracts-sdk/src/implementations/RewardsContractFactory.ts
+++ b/packages/contracts-sdk/src/implementations/RewardsContractFactory.ts
@@ -45,7 +45,7 @@ export class RewardsContractFactory implements IRewardsContractFactory {
     name: string,
     symbol: string,
     baseURI: BaseURI,
-    overrides: ContractOverrides | null = null,
+    overrides: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, RewardsFactoryError> {
     return GasUtils.getGasFee<RewardsFactoryError>(
       this.providerOrSigner,
@@ -54,12 +54,11 @@ export class RewardsContractFactory implements IRewardsContractFactory {
         ...gasFee,
         ...overrides,
       };
-      return this.writeToContract("deploy", [
-        name,
-        symbol,
-        baseURI,
+      return this.writeToContract(
+        "deploy",
+        [name, symbol, baseURI],
         contractOverrides,
-      ]);
+      );
     });
   }
 
@@ -89,11 +88,12 @@ export class RewardsContractFactory implements IRewardsContractFactory {
   protected writeToContract(
     functionName: string,
     functionParams: any[],
+    overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, RewardsFactoryError> {
     return ResultAsync.fromPromise(
-      this.contractFactory[functionName](
-        ...functionParams,
-      ) as Promise<ethers.providers.TransactionResponse>,
+      this.contractFactory[functionName](...functionParams, {
+        ...overrides,
+      }) as Promise<ethers.providers.TransactionResponse>,
       (e) => {
         return new RewardsFactoryError(
           `Unable to call ${functionName}()`,

--- a/packages/contracts-sdk/src/implementations/SiftContract.ts
+++ b/packages/contracts-sdk/src/implementations/SiftContract.ts
@@ -58,21 +58,21 @@ export class SiftContract implements ISiftContract {
     domain: DomainName,
     overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, SiftContractError> {
-    return this.writeToContract("verifyURL", [domain, overrides]);
+    return this.writeToContract("verifyURL", [domain], overrides);
   }
 
   public maliciousURL(
     domain: DomainName,
     overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, SiftContractError> {
-    return this.writeToContract("maliciousURL", [domain, overrides]);
+    return this.writeToContract("maliciousURL", [domain], overrides);
   }
 
   public setBaseURI(
     baseUri: BaseURI,
     overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, SiftContractError> {
-    return this.writeToContract("setBaseURI", [baseUri, overrides]);
+    return this.writeToContract("setBaseURI", [baseUri], overrides);
   }
 
   public getContract(): ethers.Contract {
@@ -83,11 +83,12 @@ export class SiftContract implements ISiftContract {
   protected writeToContract(
     functionName: string,
     functionParams: any[],
+    overrides?: ContractOverrides,
   ): ResultAsync<WrappedTransactionResponse, SiftContractError> {
     return ResultAsync.fromPromise(
-      this.contract[functionName](
-        ...functionParams,
-      ) as Promise<ethers.providers.TransactionResponse>,
+      this.contract[functionName](...functionParams, {
+        ...overrides,
+      }) as Promise<ethers.providers.TransactionResponse>,
       (e) => {
         return new SiftContractError(
           `Unable to call ${functionName}()`,


### PR DESCRIPTION
### Release Notes
[JIRA Link]()

#### Summary:
Previous when grouping the optional contracts override object with the params and spreading it, if there is no overrides given the contract takes it as an 'undefined' param and hence becoming an extra param to the contract call which led to errors. 

#### Intended results:
- What are the expected changes in behavior?
- List them here in simplest terms.

#### Potential Failures:
- What could possibly go wrong?
- How might those failures present within the application?

#### Relevant Metrics/Indicators:
- Are there any metrics (or indicators) that can prove or disprove the integrity of this change?
- List them here...

#### Testing Notes:
- How has this been tested?

<!---For minor fixes replace with the following --->
<!---### Minor Change
A 1-2 sentence summary on the change. If this requires more detail your change is likely not minor.-->

### Pre-Flight Checks
- [ ] Has QA approved this change for dev?
- [ ] Are all unit tests passing?
- [ ] Have you added this description to this week's [release notes](https://drive.google.com/drive/folders/1ELnyVZHgISIlwDQXgy0mb-4qsn_1PRZr?usp=sharing)?
