### PR TITLE
added cleaner to utils

### DIFF
--- a/packages/common-utils/src/implementations/ObjectUtils.ts
+++ b/packages/common-utils/src/implementations/ObjectUtils.ts
@@ -239,4 +239,22 @@ export class ObjectUtils {
       return ObjectUtils.progressiveFallback(method, provider.slice(1));
     });
   }
+
+    /**
+   * Removes properties from `object` that don't exist on the `dummyInstance` .
+   * Only properties that exist on the dummy will remain. This method mutates
+   * The object and uses the delete operation
+   */
+  static cleanExtraPropertiesOnInstances<T extends object>(object: T, dummyInstance: T): T {
+    const expectedProperties = new Set(Object.keys(dummyInstance));
+    
+    Object.keys(object).forEach(key => {
+      if (!expectedProperties.has(key)) {
+        delete (object as any)[key];
+      }
+    });
+
+    return object;
+  }
+
 }

--- a/packages/common-utils/test/unit/ObjectUtils.test.ts
+++ b/packages/common-utils/test/unit/ObjectUtils.test.ts
@@ -9,6 +9,7 @@ import { BigNumber } from "ethers";
 import { errAsync, okAsync, ResultAsync } from "neverthrow";
 
 import { ObjectUtils } from "@common-utils/implementations/ObjectUtils.js";
+import { Description } from "@ethersproject/properties";
 
 describe("ObjectUtils tests", () => {
   test("iterateCursor runs over all data", async () => {
@@ -280,8 +281,61 @@ describe("ObjectUtils tests", () => {
     const err = result._unsafeUnwrapErr();
     expect(err.message).toBe("Final Error");
   });
+
+  test("cleanExtraPropertiesOnInstances, an instance with no extra properties ", async () => {
+    // Arrange
+    const regularInstance = new TestClass(1, `desc`);
+    const dummyInstance = new TestClass( 0 ,``)
+
+    // Act
+    const result = ObjectUtils.cleanExtraPropertiesOnInstances(
+      regularInstance,
+      dummyInstance
+    );
+
+    // Assert
+    expect(result).toEqual(regularInstance);
+  });
+
+  test("cleanExtraPropertiesOnInstances, an instance , optional properties added later on, should preserve ", async () => {
+    // Arrange
+    const regularInstance = new TestClass(1, `desc`);
+    regularInstance.text = "test"
+    const dummyInstance = new TestClass( 0 ,``)
+    dummyInstance.text = ""
+
+    // Act
+    const result = ObjectUtils.cleanExtraPropertiesOnInstances(
+      regularInstance,
+      dummyInstance
+    );
+
+    // Assert
+    expect(result).toEqual(regularInstance);
+  });
+
+  test("cleanExtraPropertiesOnInstances, an instance that has props it should not have ", async () => {
+    // Arrange
+    const regularInstance = new TestClass(1, `desc`);
+    regularInstance.text = "test"
+    regularInstance[`badData`] = "badData";
+    const dummyInstance = new TestClass( 0 ,``)
+    dummyInstance.text = ""
+
+    // Act
+    const result = ObjectUtils.cleanExtraPropertiesOnInstances(
+      regularInstance,
+      dummyInstance
+    );
+    // Assert
+    expect(result[`badData`]).toEqual(undefined);
+  });
 });
 
+class TestClass {
+  text? : string;
+  constructor(public data : number , readonly description : string){}
+ }
 class TestProvider {
   public constructor(
     public returnVal: number,

--- a/packages/core/src/implementations/business/utilities/query/NftQueryEvaluator.ts
+++ b/packages/core/src/implementations/business/utilities/query/NftQueryEvaluator.ts
@@ -9,6 +9,7 @@ import {
   UnixTimestamp,
   ISDQLTimestampRange,
   NftHolding,
+  EVMContractAddress,
 } from "@snickerdoodlelabs/objects";
 import { AST_NftQuery } from "@snickerdoodlelabs/query-parser";
 import { inject, injectable } from "inversify";
@@ -19,6 +20,7 @@ import {
   IPortfolioBalanceRepository,
   IPortfolioBalanceRepositoryType,
 } from "@core/interfaces/data/index.js";
+import { ObjectUtils } from "@snickerdoodlelabs/common-utils";
 
 @injectable()
 export class NftQueryEvaluator implements INftQueryEvaluator {
@@ -43,8 +45,14 @@ export class NftQueryEvaluator implements INftQueryEvaluator {
     return this.portfolioBalanceRepository
       .getAccountNFTs(chainIds)
       .map((walletNfts) => {
+        const dummyInstance = new NftHolding(`Arbitrum` , EVMContractAddress(`0x`), 1 , "")
+        const filteredNfts = this.getNftHoldings(
+          walletNfts,
+          address,
+          timestampRange,
+        ).map(( unFilteredInstance) => ObjectUtils.cleanExtraPropertiesOnInstances(unFilteredInstance , dummyInstance));
         return SDQL_Return(
-          this.getNftHoldings(walletNfts, address, timestampRange),
+          filteredNfts
         );
       });
   }


### PR DESCRIPTION
### Release Notes
[JIRA Link]()

#### Summary:
Added a cleaner method to the nft insights. Only 
   - chain
   - tokenAddress
   - amount 
   - name
Should exist on the payloads of the insights, example 
[{
  "chain": "Astar",
  "tokenAddress": "0x3712483b262398329c794fd2e547e796e8e29501",
  "amount": 1,
  "name": "Demo Day Example 6/5"
}, {
  "chain": "Avalanche",
  "tokenAddress": "0x586a5225f3f5446eadb92b34fc920084e70c9c56",
  "amount": 1,
  "name": "Summer Fridays"
}, {
  "chain": "Avalanche",
  "tokenAddress": "0xa4097ac7462246925c3e84df73b558c7c5a641fd",
  "amount": 1,
  "name": "Free Snickerdoodle T-Shirt"
}, {
  "chain": "Avalanche",
  "tokenAddress": "0xd45492fc7cc05958405e8b22643d0f2fe33bdd6a",
  "amount": 1,
  "name": "Welcome"
}] 
#### Testing Notes:
- Join a nft campaign and check the payload. There should not be metadata or any other field other than the ones 
above

<!---For minor fixes replace with the following --->
<!---### Minor Change
A 1-2 sentence summary on the change. If this requires more detail your change is likely not minor.-->

### Pre-Flight Checks
- [ ] Has QA approved this change for dev?
- [ ] Are all unit tests passing?
- [ ] Have you added this description to this week's [release notes](https://drive.google.com/drive/folders/1ELnyVZHgISIlwDQXgy0mb-4qsn_1PRZr?usp=sharing)?
