### PR TITLE
Fix rarible api key in prod deployment script.

### DIFF
--- a/.github/workflows/prod_push_deploy.yaml
+++ b/.github/workflows/prod_push_deploy.yaml
@@ -105,7 +105,7 @@ jobs:
           --build-arg PRIMARY_INFURA_KEY=8497d7f3186c4edcaaff8838478c634d \
           --build-arg ANKR_API_KEY=f50d7a208124e6a6df731477fdc9ef420ce59769ced1e9339318a383365cb6a1 \
           --build-arg BLUEZ_API_KEY=aed4aab2cbc573bbf8e7c6b448c916e5 \
-          --build-arg RARIBILE_API_KEY=aed4aab2cbc573bbf8e7c6b448c916e5 \
+          --build-arg RARIBILE_API_KEY=c5855db8-08ef-409f-9947-e46c141af1b4 \
           --build-arg COVALENT_API_KEY=cqt_wFfHg4vmGKyMxGvPPxdHm8VCDPCY \
           --build-arg POAP_API_KEY=wInY1o7pH1yAGBYKcbz0HUIXVHv2gjNTg4v7OQ70hykVdgKlXU3g7GGaajmEarYIX4jxCwm55Oim7kYZeML6wfLJAsm7MzdvlH1k0mKFpTRLXX1AXDIwVQer51SMeuQm \
           --build-arg ALCHEMY_ARBITRUM_API_KEY=_G9cUGHUQqvD2ro5zDaTAFXeaTcNgQiF \


### PR DESCRIPTION
This should fix the Rarible api key error that show itself only on static website integration sites by updating it with the correct key.
Error:
"API key has invalid format, should be UUID". 

### Pre-Flight Checks
- [ ] Has QA approved this change for dev?
- [ ] Are all unit tests passing?
- [ ] Have you added this description to this week's [release notes](https://drive.google.com/drive/folders/1ELnyVZHgISIlwDQXgy0mb-4qsn_1PRZr?usp=sharing)?
