### PR TITLE
add max slot value to computeFee dev comment

### DIFF
--- a/packages/contracts/contracts/recomender/ContentFactoryUpgradeable.sol
+++ b/packages/contracts/contracts/recomender/ContentFactoryUpgradeable.sol
@@ -678,6 +678,7 @@ abstract contract ContentFactoryUpgradeable is IContentFactory, Initializable {
 
     /// @notice returns amount of token to pull for a given slot based on 1.0001^_slot
     /// @dev you can call this function from the client to compute the amount of token to allow this contract
+    /// @dev the max calculated _slot value is 945573
     /// @param _slot integer representing the slot in the global linked list to acquire
     function computeFee(uint256 _slot) external pure returns (uint256) {
         return _computeFee(_slot);


### PR DESCRIPTION
### Release Notes
[JIRA Link]()

#### Summary:
To avoid adding a require statement to check that _slot is below computeFee's max calculatable value of 945573, adding a dev comment to computeFee to note this limit. 
