### PR TITLE
Add generateED25519KeyPair, objects for it

### DIFF
--- a/packages/node-utils/package.json
+++ b/packages/node-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snickerdoodlelabs/node-utils",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Utilities that rely on Node APIs. They are usable in a browser with polyfills",
   "license": "MIT",
   "repository": {

--- a/packages/node-utils/src/implementations/CryptoUtils.ts
+++ b/packages/node-utils/src/implementations/CryptoUtils.ts
@@ -30,6 +30,8 @@ import {
   SuiAccountAddress,
   ED25519PublicKey,
   SignerUnavailableError,
+  NobleED25519KeyPair,
+  ED25519PrivateKey,
 } from "@snickerdoodlelabs/objects";
 // import argon2 from "argon2";
 import {
@@ -620,6 +622,27 @@ export class CryptoUtils implements ICryptoUtils {
         ),
       );
     });
+  }
+
+  public generateEd25519KeyPair(): ResultAsync<NobleED25519KeyPair, KeyGenerationError> {
+
+    const privateKeyBytes = ed.utils.randomPrivateKey(); 
+
+    return ResultAsync.fromPromise(
+        ed.getPublicKey(privateKeyBytes) as Promise<Uint8Array>,
+        (e) => {
+          return e as KeyGenerationError;
+        },
+      ).map((publicKeyBytes) => {
+
+        const publicKeyString = "0x" + Buffer.from(publicKeyBytes).toString("hex");
+        const privateKeyString = "0x" + Buffer.from(privateKeyBytes).toString("hex");
+
+        return (new NobleED25519KeyPair(
+            ED25519PublicKey(publicKeyString),
+            ED25519PrivateKey(privateKeyString)
+        ))
+      });
   }
 
   protected hexStringToBuffer(

--- a/packages/node-utils/src/interfaces/ICryptoUtils.ts
+++ b/packages/node-utils/src/interfaces/ICryptoUtils.ts
@@ -10,6 +10,7 @@ import {
   HexString,
   InvalidParametersError,
   KeyGenerationError,
+  NobleED25519KeyPair,
   OAuth1Config,
   RSAKeyPair,
   SHA256Hash,
@@ -157,6 +158,8 @@ export interface ICryptoUtils {
   getNobleED25519SignerPublicKey(
     ed25519Signer: NobleEd25519Signer,
   ): ResultAsync<ED25519PublicKey, SignerUnavailableError>;
+
+  generateEd25519KeyPair(): ResultAsync<NobleED25519KeyPair, KeyGenerationError>
 }
 
 export const ICryptoUtilsType = Symbol.for("ICryptoUtils");

--- a/packages/objects/package.json
+++ b/packages/objects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snickerdoodlelabs/objects",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "description": "Objects and types shared by the Snickerdoodle Protocol",
   "license": "MIT",
   "repository": {

--- a/packages/objects/src/businessObjects/NobleED25519KeyPair.ts
+++ b/packages/objects/src/businessObjects/NobleED25519KeyPair.ts
@@ -1,0 +1,12 @@
+import {
+    ED25519PrivateKey,
+    ED25519PublicKey,
+  } from "@objects/primitives/index.js";
+  
+  export class NobleED25519KeyPair {
+    public constructor(
+      public publicKey: ED25519PublicKey,
+      public privateKey: ED25519PrivateKey,
+    ) {}
+  }
+  

--- a/packages/objects/src/businessObjects/index.ts
+++ b/packages/objects/src/businessObjects/index.ts
@@ -63,3 +63,4 @@ export * from "@objects/businessObjects/rewards/index.js";
 export * from "@objects/businessObjects/oauth/index.js";
 export * from "@objects/businessObjects/queryResponse/index.js";
 export * from "@objects/businessObjects/versioned/index.js";
+export * from "@objects/businessObjects/NobleED25519KeyPair.js";

--- a/packages/objects/src/primitives/ED25519PrivateKey.ts
+++ b/packages/objects/src/primitives/ED25519PrivateKey.ts
@@ -1,0 +1,5 @@
+import { Brand, make } from "ts-brand";
+
+// Private key with 0x prefix
+export type ED25519PrivateKey = Brand<string, "ED25519PrivateKey">;
+export const ED25519PrivateKey = make<ED25519PrivateKey>();

--- a/packages/objects/src/primitives/index.ts
+++ b/packages/objects/src/primitives/index.ts
@@ -118,3 +118,4 @@ export * from "@objects/primitives/FarcasterEncodedSignedKeyRequestMetadata.js";
 export * from "@objects/primitives/FarcasterIDGatewayRegisterIdSignature.js";
 export * from "@objects/primitives/FarcasterKeyGatewayAddKeySignature.js";
 export * from "@objects/primitives/ED25519PublicKey.js";
+export * from "@objects/primitives/ED25519PrivateKey.js";


### PR DESCRIPTION
### Release Notes
[JIRA Link]()

#### Summary:
Adding function to generate a noble ED 25519 key pair and its respective object types in node-utils and objects package.

Publiced `objects 3.0.19`, `node-utils 2.0.3 `
