### PR TITLE
remove space and time from master indexer, republished

### DIFF
--- a/packages/indexers/package.json
+++ b/packages/indexers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snickerdoodlelabs/indexers",
-  "version": "2.2.0",
+  "version": "2.2.3",
   "description": "Account indexer implementations compatible with Snickerdoodle Core",
   "license": "ISC",
   "repository": {

--- a/packages/indexers/src/MasterIndexer.ts
+++ b/packages/indexers/src/MasterIndexer.ts
@@ -108,7 +108,6 @@ export class MasterIndexer implements IMasterIndexer {
     @inject(IRaribleIndexerType) protected rarible: IEVMIndexer,
     @inject(ISimulatorEVMTransactionRepositoryType) protected sim: IEVMIndexer,
     @inject(ISolanaIndexerType) protected sol: ISolanaIndexer,
-    @inject(ISpaceAndTimeIndexerType) protected sxt: IEVMIndexer,
     @inject(ILogUtilsType) protected logUtils: ILogUtils,
     @inject(IBigNumberUtilsType) protected bigNumberUtils: IBigNumberUtils,
     @inject(IEVMTransactionSanitizerType)
@@ -133,7 +132,6 @@ export class MasterIndexer implements IMasterIndexer {
       this.rarible.initialize(),
       this.sim.initialize(),
       this.sol.initialize(),
-      // this.sxt.initialize(),
     ])
       .andThen(() => {
         return this.getSupportedChains();
@@ -169,7 +167,6 @@ export class MasterIndexer implements IMasterIndexer {
           this.sim,
           this.sol,
           this.expand,
-          this.sxt,
         ];
 
         supportedChains = indexers
@@ -548,7 +545,6 @@ export class MasterIndexer implements IMasterIndexer {
         this.sim,
         this.sol,
         this.blockvision,
-        // this.sxt,
       ];
 
       const healthchecks = indexers.map((indexer) => {
@@ -556,7 +552,6 @@ export class MasterIndexer implements IMasterIndexer {
       });
 
       const [
-        sxtHealth,
         alchemyHealth,
         ankrHealth,
         covalentHealth,
@@ -573,7 +568,6 @@ export class MasterIndexer implements IMasterIndexer {
       ] = healthchecks;
 
       const indexerStatuses = context.components;
-      indexerStatuses.sxtIndexer = sxtHealth;
       indexerStatuses.alchemyIndexer = alchemyHealth;
       indexerStatuses.ankrIndexer = ankrHealth;
       indexerStatuses.covalentIndexer = covalentHealth;

--- a/packages/indexers/test/unit/MasterIndexer.test.ts
+++ b/packages/indexers/test/unit/MasterIndexer.test.ts
@@ -273,7 +273,6 @@ class MasterIndexerMocks {
       this.rarible,
       this.sim,
       this.sol,
-      this.sxt,
       this.logUtils,
       this.bigNumberUtils,
       this.evmTransactionSanitizer,


### PR DESCRIPTION
### Release Notes
[JIRA Link]()

#### Summary:
Remove Space and Time from `MasterIndexer`. 

Version bumped from `2.2.0` to `2.2.3` due to incorrect publishing (`yarn compile` didn't run before publishing so it was publishing the older version in the `dist` folder). 